### PR TITLE
Improve type safety and error reporting of Handler

### DIFF
--- a/lib/filesystem.mli
+++ b/lib/filesystem.mli
@@ -15,24 +15,21 @@
  *
  *)
 
+open Result
+
+type 'a or_error = ('a, Response.Err.t) result
+
 module type S = sig
-  (** A traditional protocol message handler *)
+  (** A traditional protocol message handler.
+     If an [Error] is returned, it will be reported back to the client. *)
 
-  val walk: Server.info -> Request.Walk.t -> Response.payload Error.t Lwt.t
-
-  val clunk: Server.info -> Request.Clunk.t -> Response.payload Error.t Lwt.t
-
-  val open_: Server.info -> Request.Open.t -> Response.payload Error.t Lwt.t
-
-  val read: Server.info -> Request.Read.t -> Response.payload Error.t Lwt.t
-
-  val stat: Server.info -> Request.Stat.t -> Response.payload Error.t Lwt.t
-
-  val create: Server.info -> Request.Create.t -> Response.payload Error.t Lwt.t
-
-  val write: Server.info -> Request.Write.t -> Response.payload Error.t Lwt.t
-
-  val remove: Server.info -> Request.Remove.t -> Response.payload Error.t Lwt.t
-
-  val wstat: Server.info -> Request.Wstat.t -> Response.payload Error.t Lwt.t
+  val walk: Server.info -> Request.Walk.t -> Response.Walk.t or_error Lwt.t
+  val clunk: Server.info -> Request.Clunk.t -> Response.Clunk.t or_error Lwt.t
+  val open_: Server.info -> Request.Open.t -> Response.Open.t or_error Lwt.t
+  val read: Server.info -> Request.Read.t -> Response.Read.t or_error Lwt.t
+  val stat: Server.info -> Request.Stat.t -> Response.Stat.t or_error Lwt.t
+  val create: Server.info -> Request.Create.t -> Response.Create.t or_error Lwt.t
+  val write: Server.info -> Request.Write.t -> Response.Write.t or_error Lwt.t
+  val remove: Server.info -> Request.Remove.t -> Response.Remove.t or_error Lwt.t
+  val wstat: Server.info -> Request.Wstat.t -> Response.Wstat.t or_error Lwt.t
 end

--- a/lib/response.ml
+++ b/lib/response.ml
@@ -353,3 +353,6 @@ let read rest =
   return ( { tag; payload }, rest )
 
 let to_string t = Sexplib.Sexp.to_string_hum (sexp_of_t t)
+
+let error ?errno fmt =
+  Printf.ksprintf (fun ename -> Result.Error {Err.ename; errno}) fmt

--- a/lib/response.mli
+++ b/lib/response.mli
@@ -173,3 +173,4 @@ type t = {
 include S.SERIALISABLE with type t := t
 
 val to_string: t -> string
+val error: ?errno:int32 -> ('a, unit, string, (_, Err.t) result) format4 -> 'a


### PR DESCRIPTION
Before, any method could return any response type. Now, a filesystem function must return the appropriate response type for the request, or an error to be returned to the client.

Errors are converted to the appropriate format based on the protocol version (errno is suppressed if the format does not include it, and a default is added if errno is needed and not present).

Note: wasn't sure what you want to do with errors serialising directory entries. For now, I added an `errors_to_client` function that turns them into protocol errors. They probably shouldn't happen though, so you might prefer an assert.