### PR TITLE
Break out unix-dependent logging and client; add server after_disconnect

### DIFF
--- a/.merlin
+++ b/.merlin
@@ -6,6 +6,7 @@ PKG lwt
 PKG cmdliner
 PKG stringext
 PKG bisect
+PKG oUnit
 
 S lib
 S src

--- a/_oasis
+++ b/_oasis
@@ -45,7 +45,7 @@ Library protocol_9p_unix
   Path:               unix
   Findlibparent:      protocol_9p
   Findlibname:        unix
-  Modules:            Flow_lwt_unix, Lofs9p
+  Modules:            Flow_lwt_unix, Client9p_unix, Lofs9p
   BuildDepends:       protocol-9p, mirage-types.lwt, lwt, cstruct, cstruct.lwt
 
 Executable "9p"

--- a/_oasis
+++ b/_oasis
@@ -45,7 +45,7 @@ Library protocol_9p_unix
   Path:               unix
   Findlibparent:      protocol_9p
   Findlibname:        unix
-  Modules:            Flow_lwt_unix, Client9p_unix, Lofs9p
+  Modules:            Flow_lwt_unix, Client9p_unix, Log9p_unix, Lofs9p
   BuildDepends:       protocol-9p, mirage-types.lwt, lwt, cstruct, cstruct.lwt
 
 Executable "9p"

--- a/lib/client.ml
+++ b/lib/client.ml
@@ -19,6 +19,61 @@ open Result
 open Error
 open Infix
 
+module type S = sig
+  type t
+
+  val disconnect: t -> unit Lwt.t
+  (** Disconnect from the 9P server, but leave the underlying FLOW connected. *)
+
+  val read: t -> string list -> int64 -> int32 -> Cstruct.t list Error.t Lwt.t
+  (** [read t path offset count] returns a list of buffers containing [count]
+      bytes from offset [offset] in the file given by [path] *)
+
+  val readdir: t -> string list -> Types.Stat.t list Error.t Lwt.t
+  (** Return the contents of a named directory. *)
+
+  val stat: t -> string list -> Types.Stat.t Error.t Lwt.t
+  (** Return information about a named directory or named file. *)
+
+  module KV_RO : V1_LWT.KV_RO with type t = t
+
+  module LowLevel : sig
+    (** The functions in this module are mapped directly onto individual 9P
+        RPCs. The client must carefully respect the rules on managing fids
+        and stay within the message size limits. *)
+
+    val walk: t -> Types.Fid.t -> Types.Fid.t -> string list -> Response.Walk.t Error.t Lwt.t
+    (** [walk t fid newfid wnames] binds [newfid] to the result of Walking
+        from [fid] along the path given by [wnames] *)
+
+    val openfid: t -> Types.Fid.t -> Types.OpenMode.t -> Response.Open.t Error.t Lwt.t
+    (** [open t fid mode] confirms that [fid] can be accessed according to
+        [mode] *)
+
+    val stat: t -> Types.Fid.t -> Response.Stat.t Error.t Lwt.t
+    (** [stat t fid] returns a description of the file associated with [fid] *)
+
+    val read: t -> Types.Fid.t -> int64 -> int32 -> Response.Read.t Error.t Lwt.t
+    (** [read t fid offset count] returns [count] bytes of data at [offset] in
+        the file referenced by [pid]. Note that [count] must be less than the
+        server's negotiated maximum message size. *)
+
+    val write: t -> Types.Fid.t -> int64 -> Cstruct.t -> Response.Write.t Error.t Lwt.t
+    (** [write t fid offset data] writes [data] to the file given by [fid] at
+        offset [offset]. *)
+
+    val clunk: t -> Types.Fid.t -> Response.Clunk.t Error.t Lwt.t
+    (** [clunk t fid] informs the server that the reference [fid] should be
+        forgotten about. When this call returns, it is safe for the client to
+        re-use the fid. *)
+
+    val remove: t -> Types.Fid.t -> Response.Remove.t Error.t Lwt.t
+    (** [remove t fid] removes the file associated with [fid] from the file
+        server. The server will "clunk" the fid whether the call succeeds or
+        fails. *)
+  end
+end
+
 module Make(Log: S.LOG)(FLOW: V1_LWT.FLOW) = struct
   module Reader = Buffered9PReader.Make(Log)(FLOW)
 

--- a/lib/client.mli
+++ b/lib/client.mli
@@ -15,18 +15,9 @@
  *
  *)
 
-(** Given a transport (a Mirage FLOW), construct a 9P client on top. *)
-
-module Make(Log: S.LOG)(FLOW: V1_LWT.FLOW) : sig
-
+module type S = sig
   type t
   (** An established connection to a 9P server *)
-
-  val connect: FLOW.flow -> ?msize:int32 -> ?username:string -> ?aname:string -> unit -> t Error.t Lwt.t
-  (** Establish a fresh connection to a 9P server. [msize] gives the maximum
-      message size we support: the server may choose a lower value. [username]
-      is the username to present to the remote server. [aname] is the name of
-      the exported filesystem. *)
 
   val disconnect: t -> unit Lwt.t
   (** Disconnect from the 9P server, but leave the underlying FLOW connected. *)
@@ -41,7 +32,7 @@ module Make(Log: S.LOG)(FLOW: V1_LWT.FLOW) : sig
   val stat: t -> string list -> Types.Stat.t Error.t Lwt.t
   (** Return information about a named directory or named file. *)
 
-  module KV_RO : V1_LWT.KV_RO
+  module KV_RO : V1_LWT.KV_RO with type t = t
 
   module LowLevel : sig
     (** The functions in this module are mapped directly onto individual 9P
@@ -78,4 +69,16 @@ module Make(Log: S.LOG)(FLOW: V1_LWT.FLOW) : sig
         server. The server will "clunk" the fid whether the call succeeds or
         fails. *)
   end
+end
+
+(** Given a transport (a Mirage FLOW), construct a 9P client on top. *)
+module Make(Log: S.LOG)(FLOW: V1_LWT.FLOW) : sig
+  include S
+
+  val connect: FLOW.flow -> ?msize:int32 -> ?username:string -> ?aname:string -> unit -> t Error.t Lwt.t
+  (** Establish a fresh connection to a 9P server. [msize] gives the maximum
+      message size we support: the server may choose a lower value. [username]
+      is the username to present to the remote server. [aname] is the name of
+      the exported filesystem. *)
+
 end

--- a/lib/server.ml
+++ b/lib/server.ml
@@ -54,6 +54,8 @@ module Make(Log: S.LOG)(FLOW: V1_LWT.FLOW) = struct
     t.please_shutdown <- true;
     t.shutdown_complete_t
 
+  let after_disconnect t = t.shutdown_complete_t
+
   let write_one_packet ~write_lock writer response =
     debug "S %s" (Response.to_string response);
     let sizeof = Response.sizeof response in

--- a/lib/server.mli
+++ b/lib/server.mli
@@ -30,7 +30,7 @@ type receive_cb = info -> Request.payload -> Response.payload Error.t Lwt.t
 module Make(Log: S.LOG)(FLOW: V1_LWT.FLOW) : sig
 
   type t
-  (** An established connection to a 9P server *)
+  (** An established connection to a 9P client *)
 
   val connect: FLOW.flow -> ?msize:int32 -> receive_cb:receive_cb -> unit -> t Error.t Lwt.t
   (** Establish a fresh connection to a 9P client. [msize] gives the maximum
@@ -41,4 +41,11 @@ module Make(Log: S.LOG)(FLOW: V1_LWT.FLOW) : sig
   (** Return information about the current connection *)
 
   val disconnect: t -> unit Lwt.t
+  (** [disconnect connection] causes the connection [connection] to
+      close after the next message is processed. Once the connection
+      has been disconnected, the returned thread will resolve. *)
+
+  val after_disconnect: t -> unit Lwt.t
+  (** [after_disconnect connection] resolves after [connection] has
+      disconnected. *)
 end

--- a/src/main.ml
+++ b/src/main.ml
@@ -191,11 +191,7 @@ let serve debug address path =
         | Result.Error (`Msg x) -> fail (Failure x)
         | Result.Ok t ->
           Log.debug "Successfully negotiated a connection.";
-          let rec loop_forever () =
-            Lwt_unix.sleep 60.
-            >>= fun () ->
-            loop_forever () in
-          loop_forever ()
+          Server.after_disconnect t
       ) in
   try
     ignore (Lwt_main.run t);

--- a/src/main.ml
+++ b/src/main.ml
@@ -14,6 +14,7 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *
  *)
+
 open Protocol_9p
 open Infix
 open Lwt
@@ -21,15 +22,7 @@ open Lwt
 let project_url = "http://github.com/djs55/ocaml-9p"
 let version = "0.0"
 
-module Log = struct
-  let print_debug = ref false
-
-  let debug fmt = Printf.ksprintf (fun s -> if !print_debug then print_endline s) fmt
-  let info  fmt = Printf.ksprintf (fun s -> print_endline s) fmt
-  let warn fmt = Printf.ksprintf (fun s -> print_endline s) fmt
-  let error fmt = Printf.ksprintf (fun s -> print_endline s) fmt
-end
-
+module Log = Log9p_unix.Stdout
 module Client = Client9p_unix.Inet(Log)
 module Server = Server.Make(Log)(Flow_lwt_unix)
 

--- a/unix/client9p_unix.ml
+++ b/unix/client9p_unix.ml
@@ -1,0 +1,105 @@
+(*
+ * Copyright (C) 2015 David Sheets <david.sheets@unikernel.com>
+ * Copyright (C) 2015 David Scott <dave.scott@unikernel.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ *)
+
+open Lwt
+open Protocol_9p
+
+module Inet(Log: S.LOG) = struct
+
+  module Client = Client.Make(Log)(Flow_lwt_unix)
+
+  type t = {
+    client: Client.t;
+    flow: Flow_lwt_unix.flow;
+  }
+
+  type connection = t
+
+  let connect hostname port ?msize ?username ?aname () =
+    Log.debug "Connecting to %s port %d" hostname port;
+    Lwt_unix.gethostbyname hostname
+    >>= fun h ->
+    (* This should probably be a Result error and not an Lwt error. *)
+    ( if Array.length h.Lwt_unix.h_addr_list = 0
+      then
+        let msg =
+          Printf.sprintf "gethostbyname returned 0 addresses for '%s'" hostname
+        in
+        fail (Failure msg)
+      else return h.Lwt_unix.h_addr_list.(0)
+    ) >>= fun inet_addr ->
+    let s = Lwt_unix.socket h.Lwt_unix.h_addrtype Lwt_unix.SOCK_STREAM 0 in
+    Lwt_unix.connect s (Lwt_unix.ADDR_INET (inet_addr, port))
+    >>= fun () ->
+    let flow = Flow_lwt_unix.connect s in
+    Client.connect flow ?msize ?username ?aname ()
+    >>= function
+    | Result.Error _ as err -> Lwt.return err
+    | Result.Ok client ->
+      Log.debug "Successfully negotiated a connection.";
+      Lwt.return (Result.Ok { client; flow; })
+
+  let disconnect { client; flow } =
+    Client.disconnect client
+    >>= fun () ->
+    Flow_lwt_unix.close flow
+
+  let read { client } = Client.read client
+
+  let readdir { client } = Client.readdir client
+
+  let stat { client } = Client.stat client
+
+  module KV_RO = struct
+    open Client
+
+    type t = connection
+
+    type error = KV_RO.error = Unknown_key of string
+
+    type 'a io = 'a KV_RO.io
+
+    type id = KV_RO.id
+
+    type page_aligned_buffer = KV_RO.page_aligned_buffer
+
+    let disconnect { client } = KV_RO.disconnect client
+
+    let read { client } = KV_RO.read client
+
+    let size { client } = KV_RO.size client
+  end
+
+  module LowLevel = struct
+    open Client
+
+    let walk { client } = LowLevel.walk client
+
+    let openfid { client } = LowLevel.openfid client
+
+    let stat { client } = LowLevel.stat client
+
+    let read { client } = LowLevel.read client
+
+    let write { client } = LowLevel.write client
+
+    let clunk { client } = LowLevel.clunk client
+
+    let remove { client } = LowLevel.remove client
+  end
+end

--- a/unix/client9p_unix.mli
+++ b/unix/client9p_unix.mli
@@ -1,0 +1,24 @@
+(*
+ * Copyright (C) 2015 David Sheets <david.sheets@unikernel.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ *)
+
+module Inet(Log: S.LOG) : sig
+  include Protocol_9p.Client.S
+
+  val connect:
+    string -> int -> ?msize:int32 -> ?username:string -> ?aname:string ->
+    unit -> t Error.t Lwt.t
+end

--- a/unix/log9p_unix.ml
+++ b/unix/log9p_unix.ml
@@ -1,0 +1,26 @@
+(*
+ * Copyright (C) 2015 David Scott <dave.scott@unikernel.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ *)
+
+module Stdout = struct
+  let print_debug = ref false
+
+  let debug fmt =
+    Printf.ksprintf (fun s -> if !print_debug then print_endline s) fmt
+  let info  fmt = Printf.ksprintf (fun s -> print_endline s) fmt
+  let warn fmt = Printf.ksprintf (fun s -> print_endline s) fmt
+  let error fmt = Printf.ksprintf (fun s -> print_endline s) fmt
+end

--- a/unix/log9p_unix.mli
+++ b/unix/log9p_unix.mli
@@ -1,0 +1,22 @@
+(*
+ * Copyright (C) 2015 David Sheets <david.sheets@unikernel.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ *)
+
+module Stdout : sig
+  include Protocol_9p.S.LOG
+
+  val print_debug : bool ref
+end


### PR DESCRIPTION
These changes start to factor out useful components from the main example program so they can be reused. Most of the substantive changes relate to resource clean up.

@talex5 review please.