### PR TITLE
Fix some compiler warnings

### DIFF
--- a/lib/buffered9PReader.ml
+++ b/lib/buffered9PReader.ml
@@ -20,8 +20,6 @@ open Error
 open Infix
 
 module Make(Log: S.LOG)(FLOW: V1_LWT.FLOW) = struct
-  open Log
-
   type t = {
     flow: FLOW.flow;
     read_m: Lwt_mutex.t;

--- a/lib/buffered9PReader.mli
+++ b/lib/buffered9PReader.mli
@@ -14,8 +14,6 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *
  *)
-open Result
-open Error
 
 module Make(Log: S.LOG)(FLOW: V1_LWT.FLOW) : sig
 

--- a/lib/request.ml
+++ b/lib/request.ml
@@ -15,7 +15,6 @@
  *
  *)
 open Sexplib.Std
-open Result
 open Types
 open Error
 
@@ -51,7 +50,7 @@ module Auth = struct
 
   let sizeof t =
     (Fid.sizeof t.afid) + 2 + (String.length t.uname) + 2 + (String.length t.aname)
-    + (match t.n_uname with Some x -> 4 | None -> 0)
+    + (match t.n_uname with Some _ -> 4 | None -> 0)
 
   let write t rest =
     Fid.write t.afid rest

--- a/lib/request.mli
+++ b/lib/request.mli
@@ -17,7 +17,6 @@
 
 (** Parsers and printers for all 9P request messages. *)
 
-open Sexplib.Std
 open Result
 
 module Version : sig

--- a/lib/response.ml
+++ b/lib/response.ml
@@ -69,7 +69,7 @@ module Flush = struct
 
   let sizeof _ = 0
 
-  let write t buf = return buf
+  let write () buf = return buf
 
   let read buf = return ((), buf)
 end
@@ -218,7 +218,7 @@ end
 module Clunk = struct
   type t = unit with sexp
   let sizeof _ = 0
-  let write t rest = return rest
+  let write () rest = return rest
   let read rest = return ((), rest)
 end
 

--- a/lib/response.mli
+++ b/lib/response.mli
@@ -17,7 +17,6 @@
 
 (** Parsers and printers for 9P response messages *)
 
-open Sexplib
 open Types
 open Result
 

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -261,7 +261,7 @@ module FileMode = struct
       Int32.shift_left (nibble_of_permissions mode.other) 0;
     ]
 
-  let is_any { is_any } = is_any
+  let is_any t = t.is_any
 
   let read rest =
     Int32.read rest

--- a/unix/flow_lwt_unix.ml
+++ b/unix/flow_lwt_unix.ml
@@ -34,7 +34,7 @@ let connect fd =
   let read_buffer_size = 1024 in
   { fd; read_buffer_size }
 
-let close { fd } = Lwt_unix.close fd
+let close t = Lwt_unix.close t.fd
 
 let read flow =
   let buffer = Lwt_bytes.create flow.read_buffer_size in

--- a/unix/log9p_unix.ml
+++ b/unix/log9p_unix.ml
@@ -21,6 +21,5 @@ module Stdout = struct
   let debug fmt =
     Printf.ksprintf (fun s -> if !print_debug then print_endline s) fmt
   let info  fmt = Printf.ksprintf (fun s -> print_endline s) fmt
-  let warn fmt = Printf.ksprintf (fun s -> print_endline s) fmt
   let error fmt = Printf.ksprintf (fun s -> print_endline s) fmt
 end


### PR DESCRIPTION
Would be nice to compile with warnings on by default, but I don't see how to do that with oasis without committing the `_tags` file (which we seem to be avoiding).