### PR TITLE
Provide a way to get Fids

### DIFF
--- a/lib/client.ml
+++ b/lib/client.ml
@@ -41,6 +41,9 @@ module type S = sig
     val clunk: t -> Types.Fid.t -> Response.Clunk.t Error.t Lwt.t
     val remove: t -> Types.Fid.t -> Response.Remove.t Error.t Lwt.t
   end
+
+  val walk_from_root: t -> Types.Fid.t -> string list -> Response.Walk.t Error.t Lwt.t
+  val with_fid: t -> (Types.Fid.t -> 'a Lwt.t) -> 'a Lwt.t
 end
 
 module Make(Log: S.LOG)(FLOW: V1_LWT.FLOW) = struct
@@ -253,6 +256,8 @@ module Make(Log: S.LOG)(FLOW: V1_LWT.FLOW) = struct
         Lwt.return (Ok x)
       | { Response.payload = p } -> return_error p
   end
+
+  let walk_from_root t = LowLevel.walk t t.root
 
   let rec allocate_fid t =
     let open Lwt in

--- a/lib/client.mli
+++ b/lib/client.mli
@@ -79,6 +79,14 @@ module type S = sig
         server. The server will "clunk" the fid whether the call succeeds or
         fails. *)
   end
+
+  val walk_from_root: t -> Types.Fid.t -> string list -> Response.Walk.t Error.t Lwt.t
+  (** [walk_from_root t] is [LowLevel.walk t root], where [root] is the internal Fid
+      representing the root directory (which is not exposed by the API). *)
+
+  val with_fid: t -> (Types.Fid.t -> 'a Lwt.t) -> 'a Lwt.t
+  (** [with_fid t fn] is the result of running [fn x] with a fresh Fid [x], which
+      is returned to the free pool when the thread finishes. *)
 end
 
 (** Given a transport (a Mirage FLOW), construct a 9P client on top. *)

--- a/unix/client9p_unix.ml
+++ b/unix/client9p_unix.ml
@@ -106,4 +106,7 @@ module Inet(Log: S.LOG) = struct
 
     let remove { client } = LowLevel.remove client
   end
+
+  let walk_from_root { client } = Client.walk_from_root client
+  let with_fid { client } = Client.with_fid client
 end


### PR DESCRIPTION
Otherwise, the `Client.LowLevel` API cannot be used, because all the functions require a fid but there is no way to get one (other than making them from ints, but that isn't safe since you don't know which ones the client has allocated for itself).

I expose `walk_from_root` rather than just `root` so callers can't mess up the root fid.