### PR TITLE
Begin client lofs server test suite

### DIFF
--- a/_oasis
+++ b/_oasis
@@ -69,3 +69,17 @@ Test test_parse_print
   Run$:               flag(tests)
   Command:            $test_parse_print -runner sequential
   WorkingDirectory:   lib_test
+
+Executable test_client_lofs_server
+  Path:               lib_test
+  MainIs:             lofs_test.ml
+  Build$:             flag(tests)
+  Custom:             true
+  CompiledObject:     best
+  Install:            false
+  BuildDepends:       protocol-9p.unix, oUnit (>= 1.0.2)
+
+Test test_client_lofs_server
+  Run$:               flag(tests)
+  Command:            $test_client_lofs_server -runner sequential
+  WorkingDirectory:   lib_test

--- a/lib_test/lofs_test.ml
+++ b/lib_test/lofs_test.ml
@@ -1,0 +1,160 @@
+(*
+ * Copyright (c) 2015 David Sheets <sheets@alum.mit.edu>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ *)
+
+open Protocol_9p
+open Lwt
+open Infix
+open Result
+open OUnit
+
+module LogServer  = Log9p_unix.StdoutPrefix(struct let prefix = "S" end)
+module LogClient1 = Log9p_unix.StdoutPrefix(struct let prefix = "C1" end)
+module LogClient2 = Log9p_unix.StdoutPrefix(struct let prefix = "C2" end)
+module Server = Server9p_unix.Make(LogServer)
+module Client1 = Client9p_unix.Inet(LogClient1)
+module Client2 = Client9p_unix.Inet(LogClient2)
+
+let ip = "127.0.0.1"
+let port = 5640
+
+let serve_local_fs_cb path =
+  let module Lofs = Lofs9p.New(struct let root = path end) in
+  let module Fs = Handler.Make(Lofs) in
+  (* Translate errors, especially Unix-y ones like ENOENT *)
+  fun info request ->
+    Lwt.catch
+      (fun () -> Fs.receive_cb info request)
+      (function
+       | Unix.Unix_error(err, _, _) ->
+         Lwt.return (Result.Ok (Response.Err {
+           Response.Err.ename = Unix.error_message err;
+           errno = None;
+         }))
+       | e ->
+         Lwt.return (Result.Ok (Response.Err {
+           Response.Err.ename = Printexc.to_string e;
+           errno = None;
+         })))
+
+let server_down = ref false
+let start_server listening =
+  server_down := false;
+  let path = ["tmp"] in
+  Server.serve_forever ~listening ip port (serve_local_fs_cb path)
+
+let server_tear_down pid =
+  if not !server_down
+  then begin
+    Unix.kill pid Sys.sigterm;
+    let _pid, _status = Unix.waitpid [] pid in
+    Unix.rmdir "tmp";
+    server_down := true
+  end
+
+let server_setup () =
+  Unix.mkdir "tmp" 0o700;
+  let from_child, to_parent = Unix.pipe () in
+  let ready_msg = Bytes.of_string "ready" in
+  match Lwt_unix.fork () with
+  | 0 ->
+    Unix.close from_child;
+    Lwt_main.run (
+      let ready, wakener = wait () in
+      async (fun () ->
+        ready
+        >>= fun () ->
+        let to_parent = Lwt_unix.of_unix_file_descr to_parent in
+        Lwt_unix.write to_parent ready_msg 0 5
+        >>= fun _written ->
+        return_unit
+      );
+      start_server wakener
+      >>= fun () ->
+      exit 0
+    )
+  | child ->
+    Unix.close to_parent;
+    Sys.(set_signal sigterm (Signal_handle (fun _sig ->
+      server_tear_down child;
+      exit 0
+    )));
+    Sys.(set_signal sigint (Signal_handle (fun _sig ->
+      server_tear_down child;
+      exit 0
+    )));
+    let buf = Bytes.create 5 in
+    let _read = Unix.read from_child buf 0 5 in
+    if buf = ready_msg
+    then child
+    else
+      let msg = Bytes.to_string buf in
+      assert_failure ("couldn't confirm server startup: "^msg)
+
+let with_server test =
+  bracket server_setup (fun _ -> Lwt_main.run (test ())) server_tear_down
+
+let with_client1 f =
+  Client1.connect ip port ()
+  >>= function
+  | Error (`Msg err) -> assert_failure ("client1: "^err)
+  | Ok client ->
+    Lwt.catch (fun () ->
+      f client
+      >>= fun () ->
+      Client1.disconnect client
+    ) (fun exn ->
+      Client1.disconnect client
+      >>= fun () ->
+      fail exn
+    )
+
+let with_client2 f =
+  Client2.connect ip port ()
+  >>= function
+  | Error (`Msg err) -> assert_failure ("client2: "^err)
+  | Ok client ->
+    Lwt.catch (fun () ->
+      f client
+      >>= fun () ->
+      Client2.disconnect client
+    ) (fun exn ->
+      Client2.disconnect client
+      >>= fun () ->
+      fail exn
+    )
+
+let connect1 () =
+  with_client1 (fun _client1 -> return_unit)
+
+let connect2 () =
+  with_client1 (fun _client1 ->
+    with_client2 (fun _client2 -> return_unit)
+  )
+
+let () = LogServer.print_debug := false
+let () = LogClient1.print_debug := false
+let () = LogClient2.print_debug := false
+
+let tests =
+  let connect1 = "connect1" >:: (with_server connect1) in
+  let connect2 = "connect2" >:: (with_server connect2) in
+  [ connect1; connect2 ]
+
+let () =
+  let suite = "client server" >::: tests in
+  
+  OUnit2.run_test_tt_main (ounit2_of_ounit1 suite)

--- a/src/main.ml
+++ b/src/main.ml
@@ -24,7 +24,7 @@ let version = "0.0"
 
 module Log = Log9p_unix.Stdout
 module Client = Client9p_unix.Inet(Log)
-module Server = Server.Make(Log)(Flow_lwt_unix)
+module Server = Server9p_unix.Make(Log)
 
 let finally f g =
   Lwt.catch
@@ -39,27 +39,11 @@ let finally f g =
 let parse_address address =
   try
     let colon = String.index address ':' in
-    String.sub address 0 colon, int_of_string (String.sub address (colon + 1) (String.length address - colon - 1))
+    let last = String.length address - colon - 1 in
+    String.sub address 0 colon,
+    int_of_string (String.sub address (colon + 1) last)
   with Not_found ->
     address, 5640
-
-let accept_forever address f =
-  let ip, port = parse_address address in
-  Log.debug "Listening on %s port %d" ip port;
-  let s = Lwt_unix.socket Lwt_unix.PF_INET Lwt_unix.SOCK_STREAM 0 in
-  Lwt_unix.setsockopt s Lwt_unix.SO_REUSEADDR true;
-  let sockaddr = Lwt_unix.ADDR_INET(Unix.inet_addr_of_string ip, port) in
-  Lwt_unix.bind s sockaddr;
-  Lwt_unix.listen s 5;
-  let rec loop_forever () =
-    Lwt_unix.accept s
-    >>= fun (client, _client_addr) ->
-    Lwt.async
-      (fun () ->
-        finally (fun () -> f client) (fun () -> Lwt_unix.close client)
-      );
-    loop_forever () in
-  loop_forever ()
 
 let parse_path x = Stringext.split x ~on:'/'
 
@@ -175,24 +159,21 @@ let serve_local_fs_cb path =
       (fun () -> Fs.receive_cb info request)
       (function
        | Unix.Unix_error(err, _, _) ->
-         Lwt.return (Result.Ok (Response.Err { Response.Err.ename = Unix.error_message err; errno = None }))
+         Lwt.return (Result.Ok (Response.Err {
+           Response.Err.ename = Unix.error_message err;
+           errno = None;
+         }))
        | e ->
-         Lwt.return (Result.Ok (Response.Err { Response.Err.ename = Printexc.to_string e; errno = None })))
+         Lwt.return (Result.Ok (Response.Err {
+           Response.Err.ename = Printexc.to_string e;
+           errno = None;
+         })))
 
 let serve debug address path =
   Log.print_debug := debug;
   let path = parse_path path in
-  let t =
-    accept_forever address
-      (fun fd ->
-        let flow = Flow_lwt_unix.connect fd in
-        Server.connect flow ~receive_cb:(serve_local_fs_cb path) ()
-        >>= function
-        | Result.Error (`Msg x) -> fail (Failure x)
-        | Result.Ok t ->
-          Log.debug "Successfully negotiated a connection.";
-          Server.after_disconnect t
-      ) in
+  let ip, port = parse_address address in
+  let t = Server.serve_forever ip port (serve_local_fs_cb path) in
   try
     ignore (Lwt_main.run t);
     `Ok ()

--- a/unix/log9p_unix.ml
+++ b/unix/log9p_unix.ml
@@ -23,3 +23,14 @@ module Stdout = struct
   let info  fmt = Printf.ksprintf (fun s -> print_endline s) fmt
   let error fmt = Printf.ksprintf (fun s -> print_endline s) fmt
 end
+
+module StdoutPrefix(Config : sig val prefix : string end) = struct
+  let print_debug = ref false
+
+  let print = Printf.printf "%s %s\n%!" Config.prefix
+
+  let debug fmt =
+    Printf.ksprintf (fun s -> if !print_debug then print s) fmt
+  let info  fmt = Printf.ksprintf (fun s -> print s) fmt
+  let error fmt = Printf.ksprintf (fun s -> print s) fmt
+end

--- a/unix/log9p_unix.mli
+++ b/unix/log9p_unix.mli
@@ -20,3 +20,9 @@ module Stdout : sig
 
   val print_debug : bool ref
 end
+
+module StdoutPrefix(Config: sig val prefix : string end) : sig
+  include Protocol_9p.S.LOG
+
+  val print_debug : bool ref
+end

--- a/unix/server9p_unix.ml
+++ b/unix/server9p_unix.ml
@@ -1,0 +1,68 @@
+(*
+ * Copyright (C) 2015 David Scott <dave.scott@unikernel.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ *)
+
+open Lwt
+
+module Make(Log : S.LOG) = struct
+  module Server = Protocol_9p.Server.Make(Log)(Flow_lwt_unix)
+
+  let finally f g =
+    Lwt.catch
+      (fun () ->
+         f () >>= fun result ->
+         g () >>= fun _ignored ->
+         Lwt.return result
+      ) (fun e ->
+        g () >>= fun _ignored ->
+        Lwt.fail e)
+
+  let accept_forever ?listening ip port f =
+    Log.debug "Listening on %s port %d" ip port;
+    let s = Lwt_unix.socket Lwt_unix.PF_INET Lwt_unix.SOCK_STREAM 0 in
+    Lwt_unix.setsockopt s Lwt_unix.SO_REUSEADDR true;
+    let sockaddr = Lwt_unix.ADDR_INET(Unix.inet_addr_of_string ip, port) in
+    Lwt_unix.bind s sockaddr;
+    Lwt_unix.listen s 5;
+    (match listening with
+     | Some listening -> wakeup listening ()
+     | None -> ()
+    );
+    let rec loop_forever () =
+      Lwt_unix.accept s
+      >>= fun (client, _client_addr) ->
+      print_endline "accepted connection";
+      Lwt.async
+        (fun () ->
+           finally (fun () -> f client) (fun () -> Lwt_unix.close client)
+        );
+      loop_forever ()
+    in
+    finally loop_forever (fun () -> Lwt_unix.close s)
+
+  let serve_forever ?listening ip port receive_cb =
+    accept_forever ?listening ip port
+      (fun fd ->
+         let flow = Flow_lwt_unix.connect fd in
+         Server.connect flow ~receive_cb ()
+         >>= function
+         | Result.Error (`Msg x) -> fail (Failure x)
+         | Result.Ok t ->
+           Log.debug "Successfully negotiated a connection.";
+           Server.after_disconnect t
+      )
+
+end


### PR DESCRIPTION
This contains the beginning of a new test suite for the client and lofs server implementation. It also adds a wakener hook to the `accept` loop to let other threads know when the server has started listening on the socket. This patchset uses the old `Log` functor argument and constructs 2 clients and a server each with a different logging prefix. Something along these lines is probably possible with the new logging system but I haven't investigated how to disambiguate log messages from different copies of the same library module.

I'm not very happy with the type inequality between the clients but, as it's just a test suite, I don't really care.