### PR TITLE
Support cancel/flush

### DIFF
--- a/lib/filesystem.mli
+++ b/lib/filesystem.mli
@@ -23,13 +23,13 @@ module type S = sig
   (** A traditional protocol message handler.
      If an [Error] is returned, it will be reported back to the client. *)
 
-  val walk: Server.info -> Request.Walk.t -> Response.Walk.t or_error Lwt.t
-  val clunk: Server.info -> Request.Clunk.t -> Response.Clunk.t or_error Lwt.t
-  val open_: Server.info -> Request.Open.t -> Response.Open.t or_error Lwt.t
-  val read: Server.info -> Request.Read.t -> Response.Read.t or_error Lwt.t
-  val stat: Server.info -> Request.Stat.t -> Response.Stat.t or_error Lwt.t
-  val create: Server.info -> Request.Create.t -> Response.Create.t or_error Lwt.t
-  val write: Server.info -> Request.Write.t -> Response.Write.t or_error Lwt.t
-  val remove: Server.info -> Request.Remove.t -> Response.Remove.t or_error Lwt.t
-  val wstat: Server.info -> Request.Wstat.t -> Response.Wstat.t or_error Lwt.t
+  val walk: Server.info -> cancel:unit Lwt.t -> Request.Walk.t -> Response.Walk.t or_error Lwt.t
+  val clunk: Server.info -> cancel:unit Lwt.t -> Request.Clunk.t -> Response.Clunk.t or_error Lwt.t
+  val open_: Server.info -> cancel:unit Lwt.t -> Request.Open.t -> Response.Open.t or_error Lwt.t
+  val read: Server.info -> cancel:unit Lwt.t -> Request.Read.t -> Response.Read.t or_error Lwt.t
+  val stat: Server.info -> cancel:unit Lwt.t -> Request.Stat.t -> Response.Stat.t or_error Lwt.t
+  val create: Server.info -> cancel:unit Lwt.t -> Request.Create.t -> Response.Create.t or_error Lwt.t
+  val write: Server.info -> cancel:unit Lwt.t -> Request.Write.t -> Response.Write.t or_error Lwt.t
+  val remove: Server.info -> cancel:unit Lwt.t -> Request.Remove.t -> Response.Remove.t or_error Lwt.t
+  val wstat: Server.info -> cancel:unit Lwt.t -> Request.Wstat.t -> Response.Wstat.t or_error Lwt.t
 end

--- a/lib/handler.ml
+++ b/lib/handler.ml
@@ -21,7 +21,7 @@ open Result
 open Lwt.Infix
 
 module Make(Filesystem : Filesystem.S) = struct
-  let receive_cb info =
+  let receive_cb info ~cancel =
     let is_unix = (info.Server.version = Types.Version.unix) in
     let adjust_errno err =
       if not is_unix then { err with Response.Err.errno = None }
@@ -29,7 +29,7 @@ module Make(Filesystem : Filesystem.S) = struct
       | Some _ -> err
       | None -> {err with Response.Err.errno = Some 0l} in
     let wrap fn x result =
-      fn info x >|= function
+      fn info ~cancel x >|= function
       | Ok response -> Ok (result response)
       | Error err -> Ok (Response.Err (adjust_errno err)) in
     Request.(function

--- a/lib/server.mli
+++ b/lib/server.mli
@@ -23,7 +23,7 @@ type info = {
 }
 (** Information about the active connection, passed to the receive callback. *)
 
-type receive_cb = info -> Request.payload -> Response.payload Error.t Lwt.t
+type receive_cb = info -> cancel:unit Lwt.t -> Request.payload -> Response.payload Error.t Lwt.t
 (** Every time a request is received, this is the type of the callback which
     is called. *)
 

--- a/src/main.ml
+++ b/src/main.ml
@@ -170,9 +170,9 @@ let serve_local_fs_cb path =
   let module Lofs = Lofs9p.New(struct let root = path end) in
   let module Fs = Handler.Make(Lofs) in
   (* Translate errors, especially Unix-y ones like ENOENT *)
-  fun info request ->
+  fun info ~cancel request ->
     Lwt.catch
-      (fun () -> Fs.receive_cb info request)
+      (fun () -> Fs.receive_cb info ~cancel request)
       (function
        | Unix.Unix_error(err, _, _) ->
          Lwt.return (Result.Ok (Response.Err { Response.Err.ename = Unix.error_message err; errno = None }))


### PR DESCRIPTION
When a flush request arrives, we send a cancellation signal to any active worker thread and prevent the original thread returning a response after the flush response has been sent.

This is enough to satisfy the Linux 9P client, as triggered by Control+C.