### PR TITLE
Avoid marshalling every packet to a string when not in debug mode

### DIFF
--- a/lib/s.mli
+++ b/lib/s.mli
@@ -22,6 +22,10 @@ open Result
 module type LOG = sig
   (** Common logging functions *)
 
+  (** Performance hack to avoid generating too many strings if we aren't going
+      to print them. *)
+  val print_debug: bool ref
+
   val debug : ('a, Format.formatter, unit, unit) format4 -> 'a
   val info  : ('a, Format.formatter, unit, unit) format4 -> 'a
   val error : ('a, Format.formatter, unit, unit) format4 -> 'a

--- a/lib/server.ml
+++ b/lib/server.ml
@@ -60,7 +60,7 @@ module Make(Log: S.LOG)(FLOW: V1_LWT.FLOW) = struct
   let after_disconnect t = t.shutdown_complete_t
 
   let write_one_packet ?write_lock writer response =
-    debug "S %a" Response.pp response;
+    if !Log.print_debug then debug "S %a" Response.pp response;
     let sizeof = Response.sizeof response in
     let buffer = Cstruct.create sizeof in
     Lwt.return (Response.write response buffer)
@@ -84,7 +84,7 @@ module Make(Log: S.LOG)(FLOW: V1_LWT.FLOW) = struct
         | Error (`Msg ename) ->
           Error (`Parse (ename, buffer))
         | Ok (request, _) ->
-          debug "C %a" Request.pp request;
+          if !Log.print_debug then debug "C %a" Request.pp request;
           Ok request
       end
 


### PR DESCRIPTION
The `Log.debug` function will create a string to be logged via

```
Fmt.kstrf (fun s -> if !print_debug then print_endline s) fmt
```

before deciding whether to print them or not. In debug mode we print every
packet received and transmitted. This patch ensures that, when not in
debug mode, we don't generate vast quantities of strings which we never
print.

Signed-off-by: David Scott <dave.scott@unikernel.com>