### PR TITLE
Avoid debug logging on every packet sent and received

### DIFF
--- a/lib/server.ml
+++ b/lib/server.ml
@@ -60,7 +60,7 @@ module Make(Log: S.LOG)(FLOW: V1_LWT.FLOW) = struct
   let after_disconnect t = t.shutdown_complete_t
 
   let write_one_packet ?write_lock writer response =
-    debug "S %a" Response.pp response;
+    (* debug "S %a" Response.pp response; *)
     let sizeof = Response.sizeof response in
     let buffer = Cstruct.create sizeof in
     Lwt.return (Response.write response buffer)
@@ -84,7 +84,7 @@ module Make(Log: S.LOG)(FLOW: V1_LWT.FLOW) = struct
         | Error (`Msg ename) ->
           Error (`Parse (ename, buffer))
         | Ok (request, _) ->
-          debug "C %a" Request.pp request;
+          (* debug "C %a" Request.pp request; *)
           Ok request
       end
 


### PR DESCRIPTION
When performing lots of I/O, the debug logging will generate a lot of
strings via expensive s-expression printing.

Eventually this will be made conditional via a variant of #18.

Signed-off-by: David Scott <dave.scott@unikernel.com>