### PR TITLE
lofs: Fix directory remove

### DIFF
--- a/lib/client.mli
+++ b/lib/client.mli
@@ -30,6 +30,9 @@ module type S = sig
   (** [mkdir t path name perm] creates a new directory [name] inside [path] with
    * the given permissions. *)
 
+  val remove: t -> string list -> unit Error.t Lwt.t
+  (** [remove t path] removes a file or directory from the filesystem. *)
+
   val readdir: t -> string list -> Types.Stat.t list Error.t Lwt.t
   (** Return the contents of a named directory. *)
 

--- a/lib_test/lofs_test.ml
+++ b/lib_test/lofs_test.ml
@@ -62,15 +62,14 @@ let finally f g =
 
 let with_server f =
   let path = ["tmp"] in
+  let (_: Unix.process_status) = Unix.system "chmod -R u+rw tmp/*" in
+  let (_: Unix.process_status) = Unix.system "rm -rf tmp/*" in
   (try Unix.mkdir "tmp" 0o700 with Unix.Unix_error(Unix.EEXIST, _, _) -> ());
   let server = Server.create ip port (serve_local_fs_cb path) in
   Lwt.async (fun () -> Server.serve_forever server);
   finally f
     (fun () ->
       Server.shutdown server
-      >>= fun () ->
-      let (_: Unix.process_status) = Unix.system "rm -rf tmp/*" in
-      return ()
     )
 
 let with_client1 f =

--- a/lib_test/lofs_test.ml
+++ b/lib_test/lofs_test.ml
@@ -163,6 +163,20 @@ let create_remove_file () =
       )
     )
 
+let create_remove_dir () =
+  with_client1 (fun _client1 ->
+    let filemode = Types.FileMode.make ~owner:[`Write] () in
+    Client1.mkdir _client1 [] "foo" filemode
+    >>= function
+    | Error (`Msg err) -> assert_failure ("client1: mkdir [] foo: " ^ err)
+    | Ok _ ->
+    Client1.remove _client1 ["foo"]
+    >>= function
+    | Error (`Msg err) -> assert_failure ("client1: rm [foo]: " ^ err)
+    | Ok () ->
+      Lwt.return ()
+  )
+
 let () = LogServer.print_debug := false
 let () = LogClient1.print_debug := false
 let () = LogClient2.print_debug := false
@@ -175,6 +189,7 @@ let tests = [
   lwt_test "connect2" (fun () -> with_server connect2);
   lwt_test "check that create rebinds fids" (fun () -> with_server create_rebind_fid);
   lwt_test "check that we can remove a file" (fun () -> with_server create_remove_file);
+  lwt_test "check that we can remove a directory" (fun () -> with_server create_remove_dir);
 ]
 
 let () =

--- a/unix/client9p_unix.ml
+++ b/unix/client9p_unix.ml
@@ -63,6 +63,8 @@ module Inet(Log: S.LOG) = struct
 
   let mkdir { client } = Client.mkdir client
 
+  let remove { client } = Client.remove client
+
   let readdir { client } = Client.readdir client
 
   let stat { client } = Client.stat client


### PR DESCRIPTION
- Add client helper for `remove`
- Fix `lofs` implementation of `remove` for directories
- Add test case for file remove
- Add test case for directory remove
- Make the `lofs` test cleanup more robust