### PR TITLE
Fix linux 9p2000.u mounts

### DIFF
--- a/lib/filesystem.mli
+++ b/lib/filesystem.mli
@@ -23,6 +23,7 @@ module type S = sig
   (** A traditional protocol message handler.
      If an [Error] is returned, it will be reported back to the client. *)
 
+  val attach: Server.info -> cancel:unit Lwt.t -> Request.Attach.t -> Response.Attach.t or_error Lwt.t
   val walk: Server.info -> cancel:unit Lwt.t -> Request.Walk.t -> Response.Walk.t or_error Lwt.t
   val clunk: Server.info -> cancel:unit Lwt.t -> Request.Clunk.t -> Response.Clunk.t or_error Lwt.t
   val open_: Server.info -> cancel:unit Lwt.t -> Request.Open.t -> Response.Open.t or_error Lwt.t

--- a/lib/handler.ml
+++ b/lib/handler.ml
@@ -33,6 +33,7 @@ module Make(Filesystem : Filesystem.S) = struct
       | Ok response -> Ok (result response)
       | Error err -> Ok (Response.Err (adjust_errno err)) in
     Request.(function
+    | Attach x -> wrap Filesystem.attach x (fun x -> Response.Attach x)
     | Walk x   -> wrap Filesystem.walk   x (fun x -> Response.Walk x)
     | Open x   -> wrap Filesystem.open_  x (fun x -> Response.Open x)
     | Read x   -> wrap Filesystem.read   x (fun x -> Response.Read x)
@@ -42,8 +43,8 @@ module Make(Filesystem : Filesystem.S) = struct
     | Write x  -> wrap Filesystem.write  x (fun x -> Response.Write x)
     | Remove x -> wrap Filesystem.remove x (fun x -> Response.Remove x)
     | Wstat x  -> wrap Filesystem.wstat  x (fun x -> Response.Wstat x)
-    | Version _ | Auth _ | Flush _ | Attach _ ->
-        let err = {Response.Err.ename = "not implemented"; errno = None} in
+    | Version _ | Auth _ | Flush _ ->
+        let err = {Response.Err.ename = "Function not implemented"; errno = None} in
         Lwt.return (Result.Ok (Response.Err (adjust_errno err)))
   )
 end

--- a/src/main.ml
+++ b/src/main.ml
@@ -141,7 +141,15 @@ let ls debug address path username =
            in
            let day = string_of_int tm.Unix.tm_mday in
            let year = string_of_int (1900 + tm.Unix.tm_year) in
-           let name = x.Types.Stat.name in
+           let name =
+            let name = x.Types.Stat.name in
+            if filemode.is_symlink
+            then match x.Types.Stat.u with
+              | Some { Types.Stat.extension = e } ->
+                name ^ " -> " ^ e
+              | None ->
+                name
+            else name in
            Array.of_list [
              perms; links; uid; gid; length; month; day; year; name;
            ] in

--- a/unix/lofs9p.ml
+++ b/unix/lofs9p.ml
@@ -223,6 +223,14 @@ module New(Params : sig val root : string list end) = struct
     | path ->
       walk path [] wnames
 
+  let attach info ~cancel { Request.Attach.fid } =
+    (* bind the fid as another root *)
+    fids := Types.Fid.Map.add fid Path.root !fids;
+    let realpath = Path.realpath Path.root in
+    qid_of_path realpath
+    >>*= fun qid ->
+    Lwt.return (Result.Ok { Response.Attach.qid })
+
   let stat info ~cancel { Request.Stat.fid } =
     match path_of_fid info fid with
     | exception Not_found -> bad_fid

--- a/unix/lofs9p.ml
+++ b/unix/lofs9p.ml
@@ -29,7 +29,7 @@ let errors_to_client = function
 
 (* We need to associate files with Qids with unique ids and versions *)
 let qid_of_path realpath =
-  Lwt_unix.LargeFile.stat realpath
+  Lwt_unix.LargeFile.lstat realpath
   >>= fun stats ->
   let open Types.Qid in
   let flags =


### PR DESCRIPTION
- respond to multiple `Attach` calls
- include the extension `Stat` fields
- allow symlink creation