### PR TITLE
lofs fid improvements

### DIFF
--- a/lib_test/lofs_test.ml
+++ b/lib_test/lofs_test.ml
@@ -165,7 +165,7 @@ let create_remove_file () =
 
 let create_remove_dir () =
   with_client1 (fun _client1 ->
-    let filemode = Types.FileMode.make ~owner:[`Write] () in
+    let filemode = Types.FileMode.make ~owner:[`Read; `Write] () in
     Client1.mkdir _client1 [] "foo" filemode
     >>= function
     | Error (`Msg err) -> Alcotest.fail ("client1: mkdir [] foo: " ^ err)
@@ -179,7 +179,7 @@ let create_remove_dir () =
 
 let failed_remove_clunk_fid () =
   with_client1 (fun _client1 ->
-    let filemode = Types.FileMode.make ~owner:[`Write; `Execute] () in
+    let filemode = Types.FileMode.make ~owner:[`Read; `Write; `Execute] () in
     Client1.mkdir _client1 [] "foo" filemode
     >>= function
     | Error (`Msg err) -> Alcotest.fail ("client1: mkdir [] foo: " ^ err)

--- a/lib_test/lofs_test.ml
+++ b/lib_test/lofs_test.ml
@@ -207,6 +207,36 @@ let failed_remove_clunk_fid () =
       )
   )
 
+let check_directory_boundary_read () =
+  with_client1 (fun _client1 ->
+    let filemode = Types.FileMode.make ~owner:[`Read; `Execute] () in
+    Client1.mkdir _client1 [] "foo" filemode
+    >>= function
+    | Error (`Msg err) -> Alcotest.fail ("client1: mkdir [] foo: " ^ err)
+    | Ok _ ->
+    Client1.with_fid _client1
+      (fun fid ->
+        Client1.walk_from_root _client1 fid ["foo"]
+        >>= function
+        | Error (`Msg err) -> Alcotest.fail ("client1: walk_from_root [foo]: " ^ err)
+        | Ok _ ->
+        Client1.LowLevel.openfid _client1 fid Types.OpenMode.read_only
+        >>= function
+        | Error (`Msg err) ->
+          Alcotest.fail ("client1: open: " ^ err)
+        | Ok _ ->
+        Client1.LowLevel.read _client1 fid 1024L 16l
+        >>= function
+        | Error (`Msg err) ->
+          Alcotest.fail ("client1: read: " ^ err)
+        | Ok { Response.Read.data } ->
+          let n = Cstruct.len data in
+          if n = 0
+          then Lwt.return ()
+          else Alcotest.fail ("client1: read non-zero: " ^ (string_of_int n))
+      )
+  )
+
 let () = LogServer.print_debug := false
 let () = LogClient1.print_debug := false
 let () = LogClient2.print_debug := false
@@ -221,6 +251,7 @@ let test_client = [
   lwt_test "check that we can remove a file" (fun () -> with_server create_remove_file);
   lwt_test "check that we can remove a directory" (fun () -> with_server create_remove_dir);
   lwt_test "failed remove should clunk the fid" (fun () -> with_server failed_remove_clunk_fid);
+  lwt_test "check reading out-of-bounds on a directory doesn't fail badly" (fun () -> with_server check_directory_boundary_read);
 ]
 
 let tests = [

--- a/unix/lofs9p.ml
+++ b/unix/lofs9p.ml
@@ -205,7 +205,7 @@ module New(Params : sig val root : string list end) = struct
           let rest = Cstruct.of_bigarray buffer in
           write 0L rest (Array.to_list xs)
           >>*= fun offset' ->
-          let data = Cstruct.sub rest 0 Int64.(to_int (sub offset' offset)) in
+          let data = Cstruct.sub rest 0 Int64.(to_int (max 0L (sub offset' offset))) in
           Lwt.return (Result.Ok { Response.Read.data }) in
         t >>= fun x -> Lwt.return (errors_to_client x)
       | Some (Resource.File fd) ->

--- a/unix/lofs9p.ml
+++ b/unix/lofs9p.ml
@@ -462,7 +462,7 @@ module New(Params : sig val root : string list end) = struct
       let rec loop () =
         Lwt.catch
           (fun () ->
-            Lwt_unix.LargeFile.stat realpath
+            Lwt_unix.LargeFile.lstat realpath
             >>= fun stats ->
             ( if stats.Lwt_unix.LargeFile.st_kind = Lwt_unix.S_DIR
               then Lwt_unix.rmdir else Lwt_unix.unlink ) realpath

--- a/unix/lofs9p.ml
+++ b/unix/lofs9p.ml
@@ -396,6 +396,8 @@ module New(Params : sig val root : string list end) = struct
     match path_of_fid info fid with
     | exception Not_found -> bad_fid
     | path ->
+      (* Always clunk the fid, even if remove fails *)
+      fids := Types.Fid.Map.remove fid !fids;
       let realpath = Path.realpath path in
       let rec loop () =
         Lwt.catch

--- a/unix/lofs9p.ml
+++ b/unix/lofs9p.ml
@@ -160,7 +160,7 @@ module New(Params : sig val root : string list end) = struct
     let is_open t = t.handle <> None
 
     let close t = match t.handle with
-      | None -> Lwt.return ()
+      | None -> return_unit
       | Some (File f) -> Lwt_unix.close f
       | Some (Dir d) -> Lwt_unix.closedir d
   end
@@ -246,13 +246,13 @@ module New(Params : sig val root : string list end) = struct
             Resource.of_dir resource.Resource.path
             >>= fun resource ->
             fids := Types.Fid.Map.add fid resource !fids;
-            Lwt.return ()
+            return_unit
           end else begin
             Lwt_unix.openfile realpath (flags_of_mode mode) 0
             >>= fun fd ->
             let resource = Resource.of_fd resource.Resource.path fd in
             fids := Types.Fid.Map.add fid resource !fids;
-            Lwt.return ()
+            return_unit
           end )
         >>= fun () ->
         Lwt.return (Result.Ok { Response.Open.qid; iounit = 512l })
@@ -400,7 +400,7 @@ module New(Params : sig val root : string list end) = struct
     let atime = if Types.Int32.is_any atime then 0.0 else Int32.to_float atime in
     let mtime = if Types.Int32.is_any mtime then 0.0 else Int32.to_float mtime in
     Unix.utimes path atime mtime;
-    Lwt.return ()
+    return_unit
 
   let set_length path length =
     Lwt_unix.LargeFile.truncate path length
@@ -432,19 +432,19 @@ module New(Params : sig val root : string list end) = struct
         (* TODO: check permissions *)
         (if not (Types.FileMode.is_any mode)
          then set_mode realpath mode
-         else Lwt.return ()
+         else return_unit
         ) >>= fun () ->
         (if not (Types.Int32.is_any atime && Types.Int32.is_any mtime)
          then set_times realpath atime mtime
-         else Lwt.return ()
+         else return_unit
         ) >>= fun () ->
         (if not (Types.Int64.is_any length)
          then set_length realpath length
-         else Lwt.return ()
+         else return_unit
         ) >>= fun () ->
         (if name <> ""
          then rename_local realpath name
-         else Lwt.return ()
+         else return_unit
         ) >>= fun () ->
         Lwt.return (Result.Ok ())
       end

--- a/unix/lofs9p.ml
+++ b/unix/lofs9p.ml
@@ -454,11 +454,9 @@ module New(Params : sig val root : string list end) = struct
     | exception Not_found -> bad_fid
     | path ->
       (* Always clunk the fid, even if remove fails *)
-      let resource = Types.Fid.Map.find fid !fids in
-      fids := Types.Fid.Map.remove fid !fids;
-      Resource.close resource
-      >>= fun () ->
       let realpath = Path.realpath path in
+      clunk info ~cancel { Request.Clunk.fid }
+      >>*= fun () ->
       let rec loop () =
         Lwt.catch
           (fun () ->


### PR DESCRIPTION
- walk should fail if the newfid is in use (if it is not the same as fid)
- remove should clunk the fid in the failure case
- associate open fid with file or directory handles
- `read` and `write` of a closed fid now return `bad fid`
- handle out-of-bounds directory reading a bit better