### PR TITLE
lofs: respect msize in `read`

### DIFF
--- a/lib/response.ml
+++ b/lib/response.ml
@@ -179,7 +179,9 @@ module Read = struct
     Cstruct.blit_from_string _t 0 buf 0 len;
     { data = buf }
 
-  let sizeof t = 4 + (Cstruct.len t.data)
+  let sizeof_header = 4
+
+  let sizeof t = sizeof_header + (Cstruct.len t.data)
 
   let write t rest =
     let len = Cstruct.len t.data in
@@ -363,6 +365,8 @@ let read rest =
   return ( { tag; payload }, rest )
 
 let pp ppf t = Sexplib.Sexp.pp_hum ppf (sexp_of_t t)
+
+let sizeof_header = 4 + 1 + 2
 
 let error ?errno fmt =
   Printf.ksprintf (fun ename -> Result.Error {Err.ename; errno}) fmt

--- a/lib/response.mli
+++ b/lib/response.mli
@@ -103,6 +103,9 @@ module Read : sig
   } with sexp
   (** The payload of a Read response *)
 
+  val sizeof_header: int
+  (** The size of only the header *)
+
   include S.SERIALISABLE with type t := t
 end
 
@@ -176,5 +179,8 @@ val pp: t Fmt.t
 
 val equal: t -> t -> bool
 (** [equal] is the equality function over responses. *)
+
+val sizeof_header: int
+(** The size of the fixed response header *)
 
 val error: ?errno:int32 -> ('a, unit, string, (_, Err.t) result) format4 -> 'a

--- a/lib/server.ml
+++ b/lib/server.ml
@@ -23,6 +23,7 @@ type info = {
   root: Types.Fid.t;
   version: Types.Version.t;
   aname: string;
+  msize: int32;
 }
 
 type receive_cb = info -> cancel:unit Lwt.t -> Request.payload -> Response.payload Error.t Lwt.t
@@ -229,7 +230,7 @@ module Make(Log: S.LOG)(FLOW: V1_LWT.FLOW) = struct
       >>*= fun (tag, a) ->
       let root = a.Request.Attach.fid in
       let aname = a.Request.Attach.aname in
-      let info = { root; version; aname } in
+      let info = { root; version; aname; msize } in
       let cancel, _ = Lwt.task () in
       receive_cb info ~cancel (Request.Attach a)
       >>*= fun payload ->

--- a/lib/server.mli
+++ b/lib/server.mli
@@ -21,6 +21,7 @@ type info = {
   root: Types.Fid.t;        (** The initial fid provided by the client *)
   version: Types.Version.t; (** The protocol version we negotiated *)
   aname: string;            (** The aname tree attached to *)
+  msize: int32;             (** Negotiated max message size *)
 }
 (** Information about the active connection, passed to the receive callback. *)
 

--- a/unix/lofs9p.ml
+++ b/unix/lofs9p.ml
@@ -177,6 +177,9 @@ module New(Params : sig val root : string list end) = struct
     else (Types.Fid.Map.find fid !fids).Resource.path
 
   let read info ~cancel { Request.Read.fid; offset; count } =
+    (* The client can requests a count which is larger than the negotiated msize *)
+    let max_count = Int32.(sub (sub info.Server.msize (of_int Response.sizeof_header)) (of_int Response.Read.sizeof_header)) in
+    let count = min max_count count in
     match path_of_fid info fid with
     | exception Not_found -> bad_fid
     | path ->


### PR DESCRIPTION
Some clients will negotiate an `msize` of (e.g.) 16384 and then issue a
`read` with `count=65536`, and then complain when they receive that
many bytes back. This patch makes `lofs` respect the negotiated `msize`
in `read` by returning as many bytes as possible, up to the `msize`.

Signed-off-by: David Scott <dave.scott@unikernel.com>