### PR TITLE
When pretty-printing request and response packets, don't print payloads

### DIFF
--- a/lib/protocol_9p_request.ml
+++ b/lib/protocol_9p_request.ml
@@ -498,4 +498,11 @@ let read rest =
   ) >>= fun (payload, rest) ->
   return ( { tag; payload }, rest )
 
-let pp ppf t = Sexplib.Sexp.pp_hum ppf (sexp_of_t t)
+let pp ppf = function
+  | { tag; payload = Write { Write.fid; offset; data } } ->
+    let tag = Types.Tag.to_int tag in
+    let fid = Types.Fid.to_int32 fid in
+    let len = Cstruct.len data in
+    Format.fprintf ppf "tag %d Write(fid: %ld, offset: %Ld, len(data): %d)"
+      tag fid offset len
+  | t -> Sexplib.Sexp.pp_hum ppf (sexp_of_t t)

--- a/lib/protocol_9p_response.ml
+++ b/lib/protocol_9p_response.ml
@@ -366,7 +366,12 @@ let read rest =
   ) >>= fun (payload, rest) ->
   return ( { tag; payload }, rest )
 
-let pp ppf t = Sexplib.Sexp.pp_hum ppf (sexp_of_t t)
+let pp ppf = function
+  | { tag; payload = Read { Read.data } } ->
+    let tag = Types.Tag.to_int tag in
+    let len = Cstruct.len data in
+    Format.fprintf ppf "tag %d Read(len(data): %d)" tag len
+  | t -> Sexplib.Sexp.pp_hum ppf (sexp_of_t t)
 
 let sizeof_header = 4 + 1 + 2
 

--- a/lib/protocol_9p_types.ml
+++ b/lib/protocol_9p_types.ml
@@ -133,6 +133,8 @@ module Fid = struct
     then error_msg "%ld is an invalid fid (it is defined to be NOFID in the spec)" x
     else Result.Ok x
 
+  let to_int32 x = x
+
   let sizeof _ = 4
 
   let read = Int32.read
@@ -439,6 +441,10 @@ module Tag = struct
     if x >= 0xffff || x < 0
     then error_msg "Valid tags must be between 0 <= tag < 0xffff (not %d)" x
     else return (Some x)
+
+  let to_int = function
+    | None -> -1
+    | Some x -> x
 
   let notag = None
 

--- a/lib/protocol_9p_types.mli
+++ b/lib/protocol_9p_types.mli
@@ -80,6 +80,8 @@ module Fid : sig
 
   val of_int32: int32 -> t Protocol_9p_error.t
 
+  val to_int32: t -> int32
+
   val recommended: Set.t
   (** A list of recommended fids. The client can allocate (on the server) up to
       2^32 distinct fids (in theory) but this is obviously a bad thing to do.
@@ -201,11 +203,14 @@ module Tag : sig
   (** The special tag value used during authentication *)
 
   val recommended: Set.t
-  (** A list of recommended tags. The client can generate up to 2^16 distinct tags
-      but this represents a large number of concurrent transactions. Instead clients
-      are recommended to use fids drawn from this much (much smaller) list. *)
+  (** A list of recommended tags. The client can generate up to 2^16
+      distinct tags but this represents a large number of concurrent
+      transactions. Instead clients are recommended to use fids drawn
+      from this much (much smaller) list. *)
 
   val of_int: int -> t Protocol_9p_error.t
+
+  val to_int: t -> int
 
   include Protocol_9p_s.SERIALISABLE with type t := t
 end


### PR DESCRIPTION
Read response and write request only print the size of the payloads.

Also, add some int and int32 projectors for Tags and Fids.