### PR TITLE
Handle I/O errors in dispatcher loops

### DIFF
--- a/opam
+++ b/opam
@@ -21,7 +21,7 @@ remove: ["ocamlfind" "remove" "protocol-9p"]
 depends: [
   "base-bytes"
   "cstruct"
-  "sexplib"
+  "sexplib" {<= "113.00.00" }
   "result"
   "mirage-types-lwt"
   "lwt"


### PR DESCRIPTION
Before this patch we would use `Lwt.async` to launch dispatcher
loops. Unfortunately some I/O errors manifest as exceptions/Lwt
failures (e.g. `Unix.Unix_error(Unix.SIGPIPE,_,_)`) which would
cause the `Lwt.async` to call the default async exception hook
which would quit the program.

This patch catches these errors and logs the fact that the connection
to the remote has failed.

Signed-off-by: David Scott <dave.scott@docker.com>