### PR TITLE
Allow clients to handle I/O errors, reconnections

### DIFF
--- a/lib/protocol_9p_client.mli
+++ b/lib/protocol_9p_client.mli
@@ -65,7 +65,7 @@ module type S = sig
         RPCs. The client must carefully respect the rules on managing fids
         and stay within the message size limits. *)
 
-    val allocate_fid: t -> Protocol_9p_types.Fid.t Lwt.t
+    val allocate_fid: t -> Protocol_9p_types.Fid.t Protocol_9p_error.t Lwt.t
     (** [allocate_fid t] returns a free fid. Callers must call [deallocate_fid t]
         when they are finished with it. *)
 
@@ -139,7 +139,8 @@ module type S = sig
       the internal Fid representing the root directory (which is not
       exposed by the API). *)
 
-  val with_fid: t -> (Protocol_9p_types.Fid.t -> 'a Lwt.t) -> 'a Lwt.t
+  val with_fid: t -> (Protocol_9p_types.Fid.t -> 'a Protocol_9p_error.t Lwt.t)
+      -> 'a Protocol_9p_error.t Lwt.t
   (** [with_fid t fn] is the result of running [fn x] with a fresh Fid
       [x], which is returned to the free pool when the thread
       finishes. *)

--- a/lib/protocol_9p_client.mli
+++ b/lib/protocol_9p_client.mli
@@ -65,6 +65,13 @@ module type S = sig
         RPCs. The client must carefully respect the rules on managing fids
         and stay within the message size limits. *)
 
+    val allocate_fid: t -> Protocol_9p_types.Fid.t Lwt.t
+    (** [allocate_fid t] returns a free fid. Callers must call [deallocate_fid t]
+        when they are finished with it. *)
+
+    val deallocate_fid: t -> Protocol_9p_types.Fid.t -> unit Lwt.t
+    (** [deallocate_fid t fid] clunks a fid and marks it as free for re-use. *)
+
     val walk: t -> Protocol_9p_types.Fid.t -> Protocol_9p_types.Fid.t ->
       string list -> Protocol_9p_response.Walk.t Protocol_9p_error.t Lwt.t
     (** [walk t fid newfid wnames] binds [newfid] to the result of Walking

--- a/lib/protocol_9p_client.mli
+++ b/lib/protocol_9p_client.mli
@@ -19,6 +19,10 @@ module type S = sig
   type t
   (** An established connection to a 9P server *)
 
+  val on_disconnect: t -> unit Lwt.t
+  (** A thread which wakes up when the connection to the server
+      has been broken *)
+
   val disconnect: t -> unit Lwt.t
   (** Disconnect from the 9P server, but leave the underlying FLOW
       connected. *)

--- a/lib_test/lofs_test.ml
+++ b/lib_test/lofs_test.ml
@@ -236,6 +236,17 @@ let check_directory_boundary_read () =
       )
   )
 
+let check_rpc_after_disconnect () =
+  with_client1 (fun client1 ->
+    Client1.disconnect client1
+    >>= fun () ->
+    let filemode = Types.FileMode.make ~owner:[`Read; `Execute] () in
+    Client1.mkdir client1 [] "foo" filemode
+    >>= function
+    | Error (`Msg _) -> Lwt.return ()
+    | Ok _ -> Alcotest.fail "client1: mkdir succeeded"
+  )
+
 let () = LogServer.print_debug := false
 let () = LogClient1.print_debug := false
 let () = LogClient2.print_debug := false
@@ -251,6 +262,7 @@ let test_client = [
   lwt_test "check that we can remove a directory" (fun () -> with_server create_remove_dir);
   lwt_test "failed remove should clunk the fid" (fun () -> with_server failed_remove_clunk_fid);
   lwt_test "check reading out-of-bounds on a directory doesn't fail badly" (fun () -> with_server check_directory_boundary_read);
+  lwt_test "check rpc after disconnect fails" (fun () -> with_server check_rpc_after_disconnect);
 ]
 
 let tests = [

--- a/unix/client9p_unix.ml
+++ b/unix/client9p_unix.ml
@@ -73,6 +73,8 @@ module Make(Log: S.LOG) = struct
       Log.debug "Successfully negotiated a connection.";
       Lwt.return (Result.Ok { client; flow; })
 
+  let on_disconnect { client } = Client.on_disconnect client
+
   let disconnect { client; flow } =
     Client.disconnect client
     >>= fun () ->

--- a/unix/client9p_unix.ml
+++ b/unix/client9p_unix.ml
@@ -117,6 +117,10 @@ module Make(Log: S.LOG) = struct
   module LowLevel = struct
     open Client
 
+    let allocate_fid { client } = LowLevel.allocate_fid client
+
+    let deallocate_fid { client } = LowLevel.deallocate_fid client
+
     let walk { client } = LowLevel.walk client
 
     let openfid { client } = LowLevel.openfid client


### PR DESCRIPTION
Better handling of I/O errors:

- ensure that blocked threads are woken up with errors if the dispatcher thread shuts down (otherwise they'd block forever)
- allow clients to detect whether a connection has been shutdown by exposing using the `on_disconnect` thread
- make `Flow_lwt_unix.close` idempotent for extra safety

Misc improvements:
- expose low-level fid allocation and deallocation functions to support use-cases like keeping files open permanently which didn't fit the `with_fid` pattern

Note the library doesn't handle reconnection itself, but perhaps it will in future.