### PR TITLE
Client: rename `on_disconnect` to `after_disconnect`

### DIFF
--- a/lib/protocol_9p_client.ml
+++ b/lib/protocol_9p_client.ml
@@ -28,7 +28,7 @@ module Response = Protocol_9p_response
 module type S = sig
   type t
 
-  val on_disconnect: t -> unit Lwt.t
+  val after_disconnect: t -> unit Lwt.t
 
   val disconnect: t -> unit Lwt.t
 
@@ -417,7 +417,7 @@ module Make(Log: Protocol_9p_s.LOG)(FLOW: V1_LWT.FLOW) = struct
         Lwt.return (Ok stat)
       )
 
-  let on_disconnect t = t.shutdown_complete_t
+  let after_disconnect t = t.shutdown_complete_t
 
   let disconnect t =
     let open Lwt in

--- a/lib/protocol_9p_client.mli
+++ b/lib/protocol_9p_client.mli
@@ -19,7 +19,7 @@ module type S = sig
   type t
   (** An established connection to a 9P server *)
 
-  val on_disconnect: t -> unit Lwt.t
+  val after_disconnect: t -> unit Lwt.t
   (** A thread which wakes up when the connection to the server
       has been broken *)
 

--- a/unix/client9p_unix.ml
+++ b/unix/client9p_unix.ml
@@ -73,7 +73,7 @@ module Make(Log: S.LOG) = struct
       Log.debug "Successfully negotiated a connection.";
       Lwt.return (Result.Ok { client; flow; })
 
-  let on_disconnect { client } = Client.on_disconnect client
+  let after_disconnect { client } = Client.after_disconnect client
 
   let disconnect { client; flow } =
     Client.disconnect client


### PR DESCRIPTION
This is consistent with the `after_disconnect` exposed by the server.

Signed-off-by: David Scott <dave.scott@docker.com>