### PR TITLE
Reject messages longer than 640 KB

### DIFF
--- a/lib/protocol_9p_buffered9PReader.mli
+++ b/lib/protocol_9p_buffered9PReader.mli
@@ -15,6 +15,9 @@
  *
  *)
 
+val max_message_size : int32
+(** Messages longer than this will be rejected. *)
+
 module Make(Log: Protocol_9p_s.LOG)(FLOW: V1_LWT.FLOW) : sig
 
   type t

--- a/lib/protocol_9p_server.ml
+++ b/lib/protocol_9p_server.ml
@@ -246,6 +246,7 @@ module Make(Log: Protocol_9p_s.LOG)(FLOW: V1_LWT.FLOW)(Filesystem: Protocol_9p_f
     LowLevel.expect_version ~write_lock reader writer
     >>*= fun (tag, v) ->
     let msize = min msize v.Request.Version.msize in
+    let msize = min msize Protocol_9p_buffered9PReader.max_message_size in
     if v.Request.Version.version = Types.Version.unknown then begin
       error "Client sent a 9P version string we couldn't understand";
       Lwt.return (Error (`Msg "Received unknown 9P version string"))


### PR DESCRIPTION
This is probably some kind of DoS attack. Also, we would interpret large numbers as negative, leading to:

    Invalid_argument "Bigarray.create: negative dimension"

Found using the new OCaml AFL support at https://github.com/ocamllabs/opam-repo-dev/pull/23/files