### PR TITLE
Add Filesystem.disconnect, which can clean up any allocated resources

### DIFF
--- a/lib/protocol_9p_filesystem.ml
+++ b/lib/protocol_9p_filesystem.ml
@@ -25,6 +25,7 @@ module type S = sig
   type connection
 
   val connect: t -> Protocol_9p_info.t -> connection
+  val disconnect: connection -> Protocol_9p_info.t -> unit Lwt.t
 
   val attach:
     connection ->

--- a/lib/protocol_9p_filesystem.mli
+++ b/lib/protocol_9p_filesystem.mli
@@ -35,7 +35,8 @@ module type S = sig
 
   val disconnect: connection -> Protocol_9p_info.t -> unit Lwt.t
   (** Called when the connection is closed (potentially uncleanly). This allows
-      the implementation to clear up any state still associated with the connection. *)
+      the implementation to clear up any state still associated with the connection.
+      If the thread fails then this event is logged. *)
 
   val attach:
     connection ->

--- a/lib/protocol_9p_filesystem.mli
+++ b/lib/protocol_9p_filesystem.mli
@@ -33,6 +33,10 @@ module type S = sig
   val connect: t -> Protocol_9p_info.t -> connection
   (** Called after making a connection to initialise the per-connection state *)
 
+  val disconnect: connection -> Protocol_9p_info.t -> unit Lwt.t
+  (** Called when the connection is closed (potentially uncleanly). This allows
+      the implementation to clear up any state still associated with the connection. *)
+
   val attach:
     connection ->
     cancel:unit Lwt.t ->

--- a/lib/protocol_9p_server.ml
+++ b/lib/protocol_9p_server.ml
@@ -318,7 +318,12 @@ module Make(Log: Protocol_9p_s.LOG)(FLOW: V1_LWT.FLOW)(Filesystem: Protocol_9p_f
           Lwt.wakeup_later shutdown_complete_wakener ();
           Lwt.return ()
         ) >>= fun () ->
-        Filesystem.disconnect connection info
+        Lwt.catch (fun () ->
+          Filesystem.disconnect connection info
+        ) (fun e ->
+          err (fun f -> f "Filesystem.disconnect caught: %s" (Printexc.to_string e));
+          Lwt.return ()
+        )
       );
       Lwt.return (Ok t)
     end

--- a/lib/protocol_9p_server.ml
+++ b/lib/protocol_9p_server.ml
@@ -317,7 +317,8 @@ module Make(Log: Protocol_9p_s.LOG)(FLOW: V1_LWT.FLOW)(Filesystem: Protocol_9p_f
           err (fun f -> f "dispatcher caught %s: no more requests will be handled" (Printexc.to_string e));
           Lwt.wakeup_later shutdown_complete_wakener ();
           Lwt.return ()
-        )
+        ) >>= fun () ->
+        Filesystem.disconnect connection info
       );
       Lwt.return (Ok t)
     end

--- a/lib/protocol_9p_server.ml
+++ b/lib/protocol_9p_server.ml
@@ -114,8 +114,7 @@ module Make(Log: Protocol_9p_s.LOG)(FLOW: V1_LWT.FLOW)(Filesystem: Protocol_9p_f
       | Error (`Msg message) ->
         debug (fun f -> f "S error reading: %s" message);
         debug (fun f -> f "Disconnecting client");
-        disconnect t
-        >>= fun () ->
+        t.please_shutdown <- true;
         dispatcher_t info exn_converter shutdown_complete_wakener receive_cb t
       | Error (`Parse (ename, buffer)) -> begin
           match Request.read_header buffer with

--- a/unix/lofs9p.ml
+++ b/unix/lofs9p.ml
@@ -295,6 +295,10 @@ let make root = { root }
       Lwt.return (Result.Ok ())
     end
 
+  let disconnect connection info =
+    let resources = Types.Fid.Map.fold (fun _ resource acc -> resource :: acc) !(connection.fids) [] in
+    Lwt_list.iter_s Resource.close resources
+
   let walk connection ~cancel { Request.Walk.fid; newfid; wnames } =
     let rec walk dir qids = function
       | [] ->


### PR DESCRIPTION
If a client drops its connection to the server, there may be resources
which need to be freed at the filesystem implementation level (e.g.
open file or directory handles which need closing).

Signed-off-by: David Scott <dave@recoil.org>