### PR TITLE
Log error responses at info level, not debug

### DIFF
--- a/lib/protocol_9p_server.ml
+++ b/lib/protocol_9p_server.ml
@@ -67,7 +67,11 @@ module Make(Log: Protocol_9p_s.LOG)(FLOW: V1_LWT.FLOW)(Filesystem: Protocol_9p_f
   let after_disconnect t = t.shutdown_complete_t
 
   let write_one_packet ?write_lock writer response =
-    debug (fun f -> f "S %a" Response.pp response);
+    let logger = match response.Response.payload with
+      | Response.Err _ -> info
+      | _              -> debug
+    in
+    logger (fun f -> f "S %a" Response.pp response);
     let sizeof = Response.sizeof response in
     let buffer = Cstruct.create sizeof in
     Lwt.return (Response.write response buffer)


### PR DESCRIPTION
This makes it easy to log only errors.