### PR TITLE
opam: remove dependency on ctypes

### DIFF
--- a/opam
+++ b/opam
@@ -25,7 +25,6 @@ depends: [
   "result"
   "mirage-types-lwt"
   "lwt" {>= "2.4.7"}
-  "ctypes"
   "base-unix"
   "cmdliner"
   "stringext"


### PR DESCRIPTION
This dependency is unnecessary.

Signed-off-by: David Scott <dave@recoil.org>