### PR TITLE
Add maximum_write_payload to client API

### DIFF
--- a/lib/protocol_9p_client.ml
+++ b/lib/protocol_9p_client.ml
@@ -43,6 +43,7 @@ module type S = sig
   module KV_RO : V1_LWT.KV_RO with type t = t
 
   module LowLevel : sig
+    val maximum_write_payload: t -> int32
     val allocate_fid: t -> Protocol_9p_types.Fid.t Error.t Lwt.t
     val deallocate_fid: t -> Protocol_9p_types.Fid.t -> unit Lwt.t
     val walk: t -> Types.Fid.t -> Types.Fid.t -> string list -> Response.Walk.t Error.t Lwt.t
@@ -197,6 +198,7 @@ module Make(Log: Protocol_9p_s.LOG)(FLOW: V1_LWT.FLOW) = struct
       Lwt.return (error_msg "Server sent unexpected reply: %s" (Sexplib.Sexp.to_string (Response.sexp_of_payload  payload)))
 
   module LowLevel = struct
+    let maximum_write_payload t = t.maximum_payload
 
     let flush t oldtag =
       rpc t Request.(Flush { Flush.oldtag })

--- a/lib/protocol_9p_client.mli
+++ b/lib/protocol_9p_client.mli
@@ -65,6 +65,9 @@ module type S = sig
         RPCs. The client must carefully respect the rules on managing fids
         and stay within the message size limits. *)
 
+    val maximum_write_payload: t -> int32
+    (** The largest payload that can be written in one go. *)
+
     val allocate_fid: t -> Protocol_9p_types.Fid.t Protocol_9p_error.t Lwt.t
     (** [allocate_fid t] returns a free fid. Callers must call [deallocate_fid t]
         when they are finished with it. *)
@@ -109,7 +112,7 @@ module type S = sig
     val write: t -> Protocol_9p_types.Fid.t -> int64 -> Cstruct.t ->
       Protocol_9p_response.Write.t Protocol_9p_error.t Lwt.t
     (** [write t fid offset data] writes [data] to the file given by [fid] at
-        offset [offset]. *)
+        offset [offset]. [data] must not exceed [maximum_write_payload t]. *)
 
     val clunk: t -> Protocol_9p_types.Fid.t ->
       Protocol_9p_response.Clunk.t Protocol_9p_error.t Lwt.t

--- a/unix/client9p_unix.ml
+++ b/unix/client9p_unix.ml
@@ -123,6 +123,8 @@ module Make(Log: S.LOG) = struct
   module LowLevel = struct
     open Client
 
+    let maximum_write_payload { client } = LowLevel.maximum_write_payload client
+
     let allocate_fid { client } = LowLevel.allocate_fid client
 
     let deallocate_fid { client } = LowLevel.deallocate_fid client


### PR DESCRIPTION
The API requires the client not to exceed this, but didn't provide a way
to find out what the limit was.

Signed-off-by: Thomas Leonard <thomas.leonard@docker.com>