### PR TITLE
Use Channel rather than reinvent buffering over FLOW

### DIFF
--- a/META
+++ b/META
@@ -1,7 +1,7 @@
 version = "0.6.0"
 description = "9P filesystem protocol"
 requires =
-"result cstruct sexplib sexplib mirage-types.lwt lwt stringext fmt"
+"result cstruct sexplib sexplib mirage-types.lwt lwt stringext fmt channel"
 archive(byte) = "protocol_9p.cma"
 archive(byte, plugin) = "protocol_9p.cma"
 archive(native) = "protocol_9p.cmxa"

--- a/lib/_tags
+++ b/lib/_tags
@@ -1,4 +1,4 @@
 <*.*>: package(result), package(cstruct), package(cstruct.lwt)
 <*.*>: package(sexplib), package(ppx_deriving), package(ppx_sexp_conv)
 <*.*>: package(lwt), package(mirage-types.lwt)
-<*.*>: package(stringext), package(fmt)
+<*.*>: package(stringext), package(fmt), package(channel)

--- a/lib/protocol_9p_buffered9PReader.ml
+++ b/lib/protocol_9p_buffered9PReader.ml
@@ -57,7 +57,7 @@ module Make(Log: Protocol_9p_s.LOG)(FLOW: V1_LWT.FLOW) = struct
         | length ->
         read_exactly ~len:(Int32.to_int length - len_size) t.channel
         >>= fun packet_buffer ->
-        Lwt.return (Ok (Cstruct.concat [ length_buffer; packet_buffer ]))
+        Lwt.return (Ok packet_buffer)
       ) (function
         | End_of_file -> Lwt.return (error_msg "Caught EOF on underlying FLOW")
         | C.Read_error e -> Lwt.return (error_msg "Unexpected error on underlying FLOW: %s" (FLOW.error_message e))

--- a/lib/protocol_9p_buffered9PReader.mli
+++ b/lib/protocol_9p_buffered9PReader.mli
@@ -28,5 +28,5 @@ module Make(Log: Protocol_9p_s.LOG)(FLOW: V1_LWT.FLOW) : sig
 
   val read: t -> Cstruct.t Protocol_9p_error.t Lwt.t
   (** Return the unmarshalled body of the next message read
-      from the flow. *)
+      from the flow, without the initial length field. *)
 end

--- a/lib/protocol_9p_request.ml
+++ b/lib/protocol_9p_request.ml
@@ -467,19 +467,18 @@ let write t rest =
     | Wstat x -> Wstat.write x rest
 
 let read_header rest =
-  Int32.read rest
-  >>= fun (len, rest) ->
+  (* We assume the int32 length field has already been read *)
   Int8.read rest
   >>= fun (ty, rest) ->
   Tag.read rest
   >>= fun (tag, rest) ->
-  return (len, ty, tag, rest)
+  return (ty, tag, rest)
 
 let sizeof_header = 4 + 1 + 2
 
 let read rest =
   read_header rest
-  >>= fun (len, ty, tag, rest) ->
+  >>= fun (ty, tag, rest) ->
   ( match ty with
     | 100 -> Version.read rest >>= fun (x, rest) -> return ((Version x), rest)
     | 102 -> Auth.read rest    >>= fun (x, rest) -> return ((Auth x), rest)

--- a/lib/protocol_9p_request.mli
+++ b/lib/protocol_9p_request.mli
@@ -187,7 +187,7 @@ type t = {
 include Protocol_9p_s.SERIALISABLE with type t := t
 
 val read_header:
-  Cstruct.t -> (Int32.t * Protocol_9p_types.Int8.t * Protocol_9p_types.Tag.t * Cstruct.t,
+  Cstruct.t -> (Protocol_9p_types.Int8.t * Protocol_9p_types.Tag.t * Cstruct.t,
                 [ `Msg of string]) result
 
 val sizeof_header: int

--- a/lib/protocol_9p_response.ml
+++ b/lib/protocol_9p_response.ml
@@ -341,8 +341,7 @@ let write t rest =
     | Wstat x -> Wstat.write x rest
 
 let read rest =
-  Int32.read rest
-  >>= fun (len, rest) ->
+  (* We assume the int32 length field has already been read *)
   Int8.read rest
   >>= fun (ty, rest) ->
   Tag.read rest

--- a/lib/protocol_9p_server.ml
+++ b/lib/protocol_9p_server.ml
@@ -121,7 +121,7 @@ module Make(Log: Protocol_9p_s.LOG)(FLOW: V1_LWT.FLOW)(Filesystem: Protocol_9p_f
           | Error (`Msg _) ->
             debug (fun f -> f "C sent bad header: %s" ename);
             dispatcher_t info exn_converter shutdown_complete_wakener receive_cb t
-          | Ok (_, _, tag, _) ->
+          | Ok (_, tag, _) ->
             debug (fun f -> f "C error: %s" ename);
             let response = error_response tag ename in
             write_one_packet ~write_lock:t.write_lock t.writer response

--- a/lib_test/_tags
+++ b/lib_test/_tags
@@ -3,3 +3,4 @@
 <*.*>: package(stringext)
 <*.*>: package(logs.fmt)
 <*.*>: package(astring), package(named-pipe.lwt)
+<*.*>: package(channel), package(io-page.unix)

--- a/lib_test/tests.ml
+++ b/lib_test/tests.ml
@@ -116,6 +116,8 @@ let expect_ok = function
 let request: Request.t Alcotest.testable = (module Request)
 let response: Response.t Alcotest.testable = (module Response)
 
+let len_size = 4
+
 let print_parse_request r () =
   let open Error in
   expect_ok (
@@ -123,8 +125,9 @@ let print_parse_request r () =
     let buf = Cstruct.create needed in
     Request.write r buf
     >>= fun remaining ->
+    Cstruct.hexdump buf;
     Alcotest.(check int) "write request" 0 (Cstruct.len remaining);
-    Request.read buf
+    Request.read (Cstruct.shift buf len_size)
     >>= fun (r', remaining) ->
     Alcotest.(check int) "read request" 0 (Cstruct.len remaining);
     Alcotest.(check request) "request" r r';
@@ -139,7 +142,7 @@ let print_parse_response r () =
     Response.write r buf
     >>= fun remaining ->
     Alcotest.(check int) "write response" 0 (Cstruct.len remaining);
-    Response.read buf
+    Response.read (Cstruct.shift buf len_size)
     >>= fun (r', remaining) ->
     Alcotest.(check int) "read respsonse" 0 (Cstruct.len remaining);
     Alcotest.(check response) "response" r r';

--- a/opam
+++ b/opam
@@ -24,6 +24,7 @@ depends: [
   "sexplib" {> "113.00.00" }
   "result"
   "mirage-types-lwt"
+  "channel"
   "lwt" {>= "2.4.7"}
   "base-unix"
   "cmdliner"

--- a/unix/flow_lwt_unix.ml
+++ b/unix/flow_lwt_unix.ml
@@ -33,7 +33,7 @@ type flow = {
 }
 
 let connect fd =
-  let read_buffer_size = 1024 in
+  let read_buffer_size = 32768 in
   let read_buffer = Cstruct.create read_buffer_size in
   let closed = false in
   { fd; read_buffer_size; read_buffer; closed }

--- a/unix/flow_lwt_unix.ml
+++ b/unix/flow_lwt_unix.ml
@@ -28,13 +28,15 @@ let error_message = Unix.error_message
 type flow = {
   fd: Lwt_unix.file_descr;
   read_buffer_size: int;
+  mutable read_buffer: Cstruct.t;
   mutable closed: bool;
 }
 
 let connect fd =
   let read_buffer_size = 1024 in
+  let read_buffer = Cstruct.create read_buffer_size in
   let closed = false in
-  { fd; read_buffer_size; closed }
+  { fd; read_buffer_size; read_buffer; closed }
 
 let close t =
   match t.closed with
@@ -46,14 +48,18 @@ let close t =
 
 let read flow =
   if flow.closed then return `Eof
-  else
-    let buffer = Lwt_bytes.create flow.read_buffer_size in
-    Lwt_bytes.read flow.fd buffer 0 (Lwt_bytes.length buffer)
+  else begin
+    if Cstruct.len flow.read_buffer = 0
+    then flow.read_buffer <- Cstruct.create flow.read_buffer_size;
+    Lwt_cstruct.read flow.fd flow.read_buffer
     >>= function
     | 0 ->
       return `Eof
     | n ->
-      return (`Ok (Cstruct.(sub (of_bigarray buffer) 0 n)))
+      let result = Cstruct.sub flow.read_buffer 0 n in
+      flow.read_buffer <- Cstruct.shift flow.read_buffer n;
+      return (`Ok result)
+  end
 
 let write flow buf =
   if flow.closed then return `Eof


### PR DESCRIPTION
- use the `Channel` functor to construct a buffered channel over a `FLOW`
- bump the Linux read buffer size (which limits the number of bytes `read` in one syscall) to 32KiB, which also happens to be the default Linux kernel client msize.

In the case where the whole packet payload is read in one go, this will avoid unnecessary data copies. Unfortunately if the payload is split over multiple `Cstruct.t`s then we must call `Cstruct.concat` because all the unmarshalling functions operate over `Cstruct.t` values and not `Cstruct.t list` values.