### PR TITLE
server: fix deadlock when read returns `Eof

### DIFF
--- a/lib/protocol_9p_server.ml
+++ b/lib/protocol_9p_server.ml
@@ -114,8 +114,7 @@ module Make(Log: Protocol_9p_s.LOG)(FLOW: V1_LWT.FLOW)(Filesystem: Protocol_9p_f
       | Error (`Msg message) ->
         debug (fun f -> f "S error reading: %s" message);
         debug (fun f -> f "Disconnecting client");
-        disconnect t
-        >>= fun () ->
+        t.please_shutdown <- true;
         dispatcher_t info exn_converter shutdown_complete_wakener receive_cb t
       | Error (`Parse (ename, buffer)) -> begin
           match Request.read_header buffer with


### PR DESCRIPTION
Previously the dispatcher loop would handle the Eof by calling
```
  let rec dispatcher_t ... =
    ...
    | Error (`Msg message) ->
      debug (fun f -> f "S error reading: %s" message);
      debug (fun f -> f "Disconnecting client");
      disconnect ()
      >>= fun () ->
```
where `disconnect` would set the flag and block:
```
  let disconnect () =
    t.please_shutdown <- true;
    t.shutdown_complete_t
```
Unfortunately it is the next cycle of the dispatcher which runs
```
  let rec dispatcher_t ... =
    if t.please_shutdown then begin
      Lwt.wakeup_later shutdown_complete_wakener ();
```
So before this patch the dispatcher would deadlock. This patch makes
the dispatcher set the flag only, execute the next cycle, call wakeup_later
and return. This allows the surrounding application to call `after_shutdown`
and then to close the flow.

Signed-off-by: David Scott <dave@recoil.org>