### PR TITLE
Remove the rest of stringext

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+## v0.7.2 (2016-07-15)
+
+* fix more dependency issues in the META file
+
 ## v0.7.1 (2016-07-15)
 
 * switch to topkg

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+## v0.7.3 (2016-07-18)
+
+* remove the remaining uses of stringext (in the CLI example)
+
 ## v0.7.2 (2016-07-15)
 
 * fix more dependency issues in the META file

--- a/src/_tags
+++ b/src/_tags
@@ -1,4 +1,4 @@
-<*.*>: package(stringext), package(result), package(fmt), package(lambda-term)
+<*.*>: package(astring), package(result), package(fmt), package(lambda-term)
 <*.*>: package(cstruct), package(cstruct.lwt)
 <*.*>: package(lwt)
 <*.*>: package(cmdliner, logs.fmt)


### PR DESCRIPTION
Before this PR the CLI still contained stringext references. This PR removes them.