### PR TITLE
disable tests explicitly for non-test builds

### DIFF
--- a/opam
+++ b/opam
@@ -7,7 +7,7 @@ dev-repo:     "https://github.com/mirage/ocaml-9p.git"
 bug-reports:  "https://github.com/mirage/ocaml-9p/issues"
 doc:          "https://mirage.github.io/ocaml-9p/"
 
-build: ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%"
+build: ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "false"
           "--with-lambda-term" "%{lambda-term:installed}%"]
 
 build-test: [


### PR DESCRIPTION
They seem to be built otherwise in some builds, e.g.
https://github.com/mirage/mirage-ci.logs/tree/docker-build-4188a791843f6bdfd2fdecfe8f0cfa78