### PR TITLE
RFC: patches used by DataKit

### DIFF
--- a/_tags
+++ b/_tags
@@ -1,5 +1,5 @@
 true: warn(@5@8@10@11@12@14@23@24@26@29@40), annot, bin_annot, safe_string, debug
-true: package(logs rresult)
+true: package(logs prometheus rresult)
 
 "lib": include
 "unix": include

--- a/opam
+++ b/opam
@@ -32,6 +32,7 @@ depends: [
   "named-pipe" {>= "0.4.0"}
   "fmt"
   "logs" {>= "0.5.0"}
+  "prometheus"
   "win-error"
   "ppx_deriving" {build}
   "ppx_sexp_conv" {build}

--- a/pkg/META
+++ b/pkg/META
@@ -1,6 +1,6 @@
 description = "9P filesystem protocol"
 version = "0.9.0"
-requires = "result rresult cstruct sexplib mirage-kv-lwt mirage-flow-lwt mirage-channel-lwt lwt astring fmt"
+requires = "result rresult cstruct sexplib mirage-kv-lwt mirage-flow-lwt mirage-channel-lwt lwt astring fmt prometheus"
 archive(byte) = "protocol-9p.cma"
 archive(native) = "protocol-9p.cmxa"
 plugin(byte) = "protocol-9p.cma"

--- a/unix/client9p_unix.ml
+++ b/unix/client9p_unix.ml
@@ -22,6 +22,15 @@ open Protocol_9p
 open Astring
 open Protocol_9p.Infix
 
+module Metrics = struct
+  let namespace = "ocaml9p"
+  let subsystem = "client"
+
+  let db_ping_time_seconds =
+    let help = "Time to receive a response to a ping message" in
+    Prometheus.Summary.v ~help ~namespace ~subsystem "ping_time_seconds"
+end
+
 module Make(Log: S.LOG) = struct
 
   module Client = Client.Make(Log)(Flow_lwt_unix)
@@ -29,6 +38,7 @@ module Make(Log: S.LOG) = struct
   type t = {
     client: Client.t;
     flow: Flow_lwt_unix.flow;
+    switch : Lwt_switch.t;
   }
 
   type connection = t
@@ -66,6 +76,26 @@ module Make(Log: S.LOG) = struct
     let s = Lwt_unix.socket Lwt_unix.PF_UNIX Lwt_unix.SOCK_STREAM 0 in
     connect_or_close s (Lwt_unix.ADDR_UNIX path)
 
+  let rec ping_thread ~switch t =
+    Client.with_fid t.client (fun newfid ->
+        let t0 = Unix.gettimeofday () in
+        Client.walk_from_root t.client newfid [] >>*= fun _ ->
+        Prometheus.Summary.observe Metrics.db_ping_time_seconds (Unix.gettimeofday () -. t0);
+        Lwt.return (Ok ())
+      )
+    >>= fun result ->
+    if Lwt_switch.is_on switch then (
+      match result with
+      | Ok () ->
+        Lwt_unix.sleep 30.0 >>= fun () ->
+        ping_thread ~switch t
+      | Error (`Msg e) ->
+        Log.err (fun f -> f "Ping failed: %s" e);
+        Lwt_switch.turn_off switch
+    ) else (
+      Lwt.return_unit
+    )
+
   let connect proto address ?msize ?username ?aname ?max_fids  () =
     ( match proto, address with
       | "tcp", _ ->
@@ -90,14 +120,21 @@ module Make(Log: S.LOG) = struct
     | Result.Error _ as err -> Lwt.return err
     | Result.Ok client ->
       Log.debug (fun f -> f "Successfully negotiated a connection.");
-      Lwt.return (Result.Ok { client; flow; })
+      let switch = Lwt_switch.create () in
+      let t = { client; flow; switch } in
+      Lwt_switch.add_hook (Some switch)
+        (fun () ->
+           Client.disconnect client
+           >>= fun () ->
+           Flow_lwt_unix.close flow
+        );
+      Lwt.async (fun () -> ping_thread ~switch t);
+      Lwt.return (Result.Ok t)
 
   let after_disconnect { client } = Client.after_disconnect client
 
-  let disconnect { client; flow } =
-    Client.disconnect client
-    >>= fun () ->
-    Flow_lwt_unix.close flow
+  let disconnect t =
+    Lwt_switch.turn_off t.switch
 
   let create { client } = Client.create client
 


### PR DESCRIPTION
For DataKit, we apply these patches to ocaml-9p. I'm not sure we want them merged upstream in this form, but I'm making this PR to keep track of them:

* When logging exceptions, include the 9p request that triggered it for debugging. Maybe the signature of `exn_converter` should be changed instead?

* While a connection is open, send a ping message (walk to `/`) every 30s. This avoids problems in some networks where TCP connections may silently stop working after a while unless there is traffic to keep the connection alive. It also reports these ping times as prometheus metrics. This should probably be optional.