### PR TITLE
protocol-9p-unix needs io-page.unix to link properly

### DIFF
--- a/lib_test/jbuild
+++ b/lib_test/jbuild
@@ -1,6 +1,8 @@
 (executables
  ((names (lofs_test tests))
-  (libraries   (result cstruct alcotest lwt cstruct.lwt logs.fmt astring named-pipe.lwt io-page.unix mirage-flow-lwt mirage-kv-lwt mirage-channel-lwt protocol-9p protocol-9p-unix))
+  (libraries (result cstruct alcotest lwt cstruct.lwt logs.fmt astring
+              named-pipe.lwt mirage-flow-lwt mirage-kv-lwt mirage-channel-lwt
+              protocol-9p protocol-9p-unix))
 ))
 (alias
  ((name    runtest)

--- a/src/jbuild
+++ b/src/jbuild
@@ -1,9 +1,9 @@
 (executables
  ((names (main))
-  (libraries (protocol_9p protocol_9p_unix io-page.unix logs logs.fmt rresult win-error lambda-term cmdliner))))
+  (libraries (protocol_9p protocol_9p_unix logs logs.fmt rresult win-error
+              lambda-term cmdliner))))
 
 (install
  ((section bin)
   (package protocol-9p-tool)
   (files ((main.exe as 9p-tool)))))
-

--- a/unix/jbuild
+++ b/unix/jbuild
@@ -1,5 +1,6 @@
 (library
  ((name        protocol_9p_unix)
   (public_name protocol-9p-unix)
-  (libraries   (result fmt lwt mirage-flow-lwt cstruct astring named-pipe.lwt protocol_9p))
+  (libraries   (result fmt lwt mirage-flow-lwt cstruct astring named-pipe.lwt
+                protocol_9p io-page.unix))
 ))


### PR DESCRIPTION
`protocol-9p` uses `mirage-channel` which uses `io-page` which will fail to link on Unix without a dependency to `io-page.unix`. 

/cc @djs55 