### PR TITLE
client: ping server, add prometheus metrics

### DIFF
--- a/protocol-9p.opam
+++ b/protocol-9p.opam
@@ -31,6 +31,7 @@ depends: [
   "named-pipe" {>= "0.4.0"}
   "fmt"
   "logs" {>= "0.5.0"}
+  "prometheus"
   "win-error"
   "ppx_deriving" {build}
   "ppx_sexp_conv" {build}

--- a/unix/client9p_unix.ml
+++ b/unix/client9p_unix.ml
@@ -26,7 +26,7 @@ module Metrics = struct
   let namespace = "ocaml9p"
   let subsystem = "client"
 
-  let db_ping_time_seconds =
+  let server_ping_time_seconds =
     let help = "Time to receive a response to a ping message" in
     Prometheus.Summary.v ~help ~namespace ~subsystem "ping_time_seconds"
 end
@@ -80,7 +80,7 @@ module Make(Log: S.LOG) = struct
     Client.with_fid t.client (fun newfid ->
         let t0 = Unix.gettimeofday () in
         Client.walk_from_root t.client newfid [] >>*= fun _ ->
-        Prometheus.Summary.observe Metrics.db_ping_time_seconds (Unix.gettimeofday () -. t0);
+        Prometheus.Summary.observe Metrics.server_ping_time_seconds (Unix.gettimeofday () -. t0);
         Lwt.return (Ok ())
       )
     >>= fun result ->

--- a/unix/client9p_unix.ml
+++ b/unix/client9p_unix.ml
@@ -96,7 +96,7 @@ module Make(Log: S.LOG) = struct
       Lwt.return_unit
     )
 
-  let connect proto address ?msize ?username ?aname ?max_fids  () =
+  let connect proto address ?msize ?username ?aname ?max_fids ?(send_pings=false) () =
     ( match proto, address with
       | "tcp", _ ->
         begin match String.cuts ~sep:":" address with
@@ -128,7 +128,7 @@ module Make(Log: S.LOG) = struct
            >>= fun () ->
            Flow_lwt_unix.close flow
         );
-      Lwt.async (fun () -> ping_thread ~switch t);
+      if send_pings then Lwt.async (fun () -> ping_thread ~switch t);
       Lwt.return (Result.Ok t)
 
   let after_disconnect { client } = Client.after_disconnect client

--- a/unix/client9p_unix.ml
+++ b/unix/client9p_unix.ml
@@ -22,6 +22,15 @@ open Protocol_9p
 open Astring
 open Protocol_9p.Infix
 
+module Metrics = struct
+  let namespace = "ocaml9p"
+  let subsystem = "client"
+
+  let db_ping_time_seconds =
+    let help = "Time to receive a response to a ping message" in
+    Prometheus.Summary.v ~help ~namespace ~subsystem "ping_time_seconds"
+end
+
 module Make(Log: S.LOG) = struct
 
   module Client = Client.Make(Log)(Flow_lwt_unix)
@@ -29,6 +38,7 @@ module Make(Log: S.LOG) = struct
   type t = {
     client: Client.t;
     flow: Flow_lwt_unix.flow;
+    switch : Lwt_switch.t;
   }
 
   type connection = t
@@ -66,6 +76,26 @@ module Make(Log: S.LOG) = struct
     let s = Lwt_unix.socket Lwt_unix.PF_UNIX Lwt_unix.SOCK_STREAM 0 in
     connect_or_close s (Lwt_unix.ADDR_UNIX path)
 
+  let rec ping_thread ~switch t =
+    Client.with_fid t.client (fun newfid ->
+        let t0 = Unix.gettimeofday () in
+        Client.walk_from_root t.client newfid [] >>*= fun _ ->
+        Prometheus.Summary.observe Metrics.db_ping_time_seconds (Unix.gettimeofday () -. t0);
+        Lwt.return (Ok ())
+      )
+    >>= fun result ->
+    if Lwt_switch.is_on switch then (
+      match result with
+      | Ok () ->
+        Lwt_unix.sleep 30.0 >>= fun () ->
+        ping_thread ~switch t
+      | Error (`Msg e) ->
+        Log.err (fun f -> f "Ping failed: %s" e);
+        Lwt_switch.turn_off switch
+    ) else (
+      Lwt.return_unit
+    )
+
   let connect proto address ?msize ?username ?aname ?max_fids  () =
     ( match proto, address with
       | "tcp", _ ->
@@ -90,14 +120,21 @@ module Make(Log: S.LOG) = struct
     | Result.Error _ as err -> Lwt.return err
     | Result.Ok client ->
       Log.debug (fun f -> f "Successfully negotiated a connection.");
-      Lwt.return (Result.Ok { client; flow; })
+      let switch = Lwt_switch.create () in
+      let t = { client; flow; switch } in
+      Lwt_switch.add_hook (Some switch)
+        (fun () ->
+           Client.disconnect client
+           >>= fun () ->
+           Flow_lwt_unix.close flow
+        );
+      Lwt.async (fun () -> ping_thread ~switch t);
+      Lwt.return (Result.Ok t)
 
   let after_disconnect { client } = Client.after_disconnect client
 
-  let disconnect { client; flow } =
-    Client.disconnect client
-    >>= fun () ->
-    Flow_lwt_unix.close flow
+  let disconnect t =
+    Lwt_switch.turn_off t.switch
 
   let create { client } = Client.create client
 

--- a/unix/client9p_unix.mli
+++ b/unix/client9p_unix.mli
@@ -20,11 +20,14 @@ module Make(Log: Protocol_9p.S.LOG) : sig
 
   val connect:
     string -> string -> ?msize:int32 -> ?username:string -> ?aname:string ->
-    ?max_fids:int32 -> unit -> t Protocol_9p.Error.t Lwt.t
+    ?max_fids:int32 -> ?send_pings:bool -> unit -> t Protocol_9p.Error.t Lwt.t
   (** [connect proto address ?msize ?username ?aname ()] creates a 9P connection
       over [proto] to [address] with an optional maximum message size [?msize]
       and optional [?username] and authentication [?aname]. [max_fids] is the
-      maximal numbers of files concurrently opened  by the client.
+      maximal numbers of files concurrently opened  by the client. If [?send_pings]
+      is true then regular "walk"s to / will be used to keep the connection alive--
+      this is useful over TCP connections where stateful middleboxes silently
+      drop connections.
       Allowed combinations
       of [proto] and [address] are:
       - unix /path/to/file

--- a/unix/jbuild
+++ b/unix/jbuild
@@ -2,5 +2,5 @@
  ((name        protocol_9p_unix)
   (public_name protocol-9p-unix)
   (libraries   (result fmt lwt mirage-flow-lwt cstruct astring named-pipe.lwt
-                protocol_9p io-page.unix))
+                protocol_9p io-page.unix prometheus))
 ))


### PR DESCRIPTION
This is a tweaked subset of #118, about which @talex5 writes:

> While a connection is open, send a ping message (walk to /) every 30s. This avoids problems in some networks where TCP connections may silently stop working after a while unless there is traffic to keep the connection alive. It also reports these ping times as prometheus metrics. This should probably be optional.

Note this is now optional and can be activated with `connect ~send_pings:true`