### PR TITLE
Prepare to release v0.11.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,6 @@ script: bash -ex .travis-opam.sh
 sudo: required
 env:
   global:
-    - PACKAGE="protocol-9p"
+    - PACKAGE="protocol-9p-unix"
     - OCAML_VERSION=4.03
     - DEPOPTS="named-pipe"

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+## v0.11.0 (2017-05-07)
+
+* protocol-9p-unix: add missing dependency on io-page.unix
+* protocol-9p-unix: add optional periodic ping thread to keep connections alive
+* protocol-9p-unix: add prometheus metrics integration
+
 ## v0.10.0 (2017-04-28)
 
 * Update to lwt.3.0.0

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,6 @@ platform:
 environment:
   CYG_ROOT: "C:\\cygwin"
   CYG_BASH: "%CYG_ROOT%\\bin\\bash -lc"
-  EXTRA_REMOTES: "https://github.com/mirage/mirage-dev.git"
   PACKAGE: "protocol-9p-unix"
 
 install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,6 +5,7 @@ environment:
   CYG_ROOT: "C:\\cygwin"
   CYG_BASH: "%CYG_ROOT%\\bin\\bash -lc"
   PACKAGE: "protocol-9p-unix"
+  PINS: "prometheus:https://github.com/mirage/prometheus.git"
 
 install:
   - appveyor DownloadFile https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/appveyor-opam.sh

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ environment:
   CYG_ROOT: "C:\\cygwin"
   CYG_BASH: "%CYG_ROOT%\\bin\\bash -lc"
   EXTRA_REMOTES: "https://github.com/mirage/mirage-dev.git"
-  PACKAGE: "protocol-9p"
+  PACKAGE: "protocol-9p-unix"
 
 install:
   - appveyor DownloadFile https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/appveyor-opam.sh

--- a/protocol-9p-unix.opam
+++ b/protocol-9p-unix.opam
@@ -20,6 +20,7 @@ depends: [
   "base-bytes"
   "cstruct" {>= "1.9.0"}
   "sexplib" {> "113.00.00" }
+  "prometheus"
   "result"
   "rresult"
   "mirage-flow-lwt"

--- a/protocol-9p.opam
+++ b/protocol-9p.opam
@@ -31,7 +31,6 @@ depends: [
   "named-pipe" {>= "0.4.0"}
   "fmt"
   "logs" {>= "0.5.0"}
-  "prometheus"
   "win-error"
   "ppx_deriving" {build}
   "ppx_sexp_conv" {build}


### PR DESCRIPTION
- update `CHANGES.md`
- move the `prometheus` dependency to the `protocol-9p-unix.opam` file
- ensure that travis and appveyor installs the `protocol-9p-unix` package, needed by the tests