### PR TITLE
unix: remove dependency on io-page-unix

### DIFF
--- a/unix/jbuild
+++ b/unix/jbuild
@@ -4,5 +4,5 @@
  ((name        protocol_9p_unix)
   (public_name protocol-9p-unix)
   (libraries   (result fmt lwt mirage-flow-lwt cstruct cstruct-lwt astring named-pipe.lwt
-                protocol-9p io-page.unix prometheus))
+                protocol-9p prometheus))
 ))


### PR DESCRIPTION
It looks like this was declared in the jbuild, but is not actually needed.

Signed-off-by: David Scott <dave@recoil.org>