### PR TITLE
Remove unnecessary Unix dependency

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+## v0.11.3 (2017-09-15)
+
+* Remove unnecessary Unix dependency from core library
+
 ## v0.11.2 (2016-06-17)
 * Add dependency on io-page-unix
 * Modernise travis and appveyor

--- a/lib/jbuild
+++ b/lib/jbuild
@@ -3,6 +3,6 @@
 (library
  ((name        protocol_9p)
   (public_name protocol-9p)
-  (libraries   (result rresult cstruct cstruct-lwt sexplib lwt mirage-flow-lwt mirage-channel-lwt mirage-kv-lwt astring fmt))
+  (libraries   (result rresult cstruct sexplib lwt mirage-flow-lwt mirage-channel-lwt mirage-kv-lwt astring fmt))
   (preprocess (pps (ppx_sexp_conv)))
 ))

--- a/protocol-9p-unix.opam
+++ b/protocol-9p-unix.opam
@@ -15,7 +15,8 @@ depends: [
   "jbuilder" {build & >="1.0+beta10"}
   "protocol-9p"
   "base-bytes"
-  "cstruct" {>= "1.9.0"}
+  "cstruct" {>= "3.0.0"}
+  "cstruct-lwt" {>= "3.0.0"}
   "sexplib" {> "113.00.00" }
   "prometheus"
   "result"

--- a/protocol-9p.opam
+++ b/protocol-9p.opam
@@ -15,7 +15,6 @@ depends: [
   "jbuilder" {build & >= "1.0+beta10"}
   "base-bytes"
   "cstruct" {>= "3.0.0"}
-  "cstruct-lwt" {>= "3.0.0"}
   "sexplib" {> "113.00.00"}
   "result"
   "rresult"
@@ -23,7 +22,6 @@ depends: [
   "mirage-kv-lwt"
   "mirage-channel-lwt"
   "lwt" {>= "3.0.0"}
-  "base-unix"
   "cmdliner"
   "astring"
   "named-pipe" {>= "0.4.0"}

--- a/unix/jbuild
+++ b/unix/jbuild
@@ -3,6 +3,6 @@
 (library
  ((name        protocol_9p_unix)
   (public_name protocol-9p-unix)
-  (libraries   (result fmt lwt mirage-flow-lwt cstruct astring named-pipe.lwt
+  (libraries   (result fmt lwt mirage-flow-lwt cstruct cstruct-lwt astring named-pipe.lwt
                 protocol-9p io-page.unix prometheus))
 ))


### PR DESCRIPTION
The `cstruct-lwt` package depends on `lwt.unix` and is only needed by `protocol-9p-unix`.