### PR TITLE
Remove broken named pipe support

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+## v0.12.1 (2018-06-14)
+
+* Remove (broken) support for named pipes.
+* Remove unnecessary dependency on `cmdliner` in the core library.
+
 ## v0.12.0 (2017-11-05)
 
 * Remove unnecessary dependency on `ppx_deriving`

--- a/lib_test/jbuild
+++ b/lib_test/jbuild
@@ -3,7 +3,7 @@
 (executables
  ((names (lofs_test tests))
   (libraries (result cstruct alcotest lwt cstruct-lwt logs.fmt astring
-              named-pipe.lwt mirage-flow-lwt mirage-kv-lwt mirage-channel-lwt
+              mirage-flow-lwt mirage-kv-lwt mirage-channel-lwt
               protocol-9p protocol-9p-unix))
 ))
 (alias

--- a/protocol-9p-unix.opam
+++ b/protocol-9p-unix.opam
@@ -28,7 +28,6 @@ depends: [
   "base-unix"
   "cmdliner"
   "astring"
-  "named-pipe" {>= "0.4.0"}
   "fmt"
   "logs" {>= "0.5.0"}
   "win-error"

--- a/protocol-9p-unix.opam
+++ b/protocol-9p-unix.opam
@@ -26,7 +26,6 @@ depends: [
   "mirage-channel-lwt"
   "lwt" {>= "3.0.0"}
   "base-unix"
-  "cmdliner"
   "astring"
   "fmt"
   "logs" {>= "0.5.0"}

--- a/protocol-9p.opam
+++ b/protocol-9p.opam
@@ -22,7 +22,6 @@ depends: [
   "mirage-kv-lwt"
   "mirage-channel-lwt"
   "lwt" {>= "3.0.0"}
-  "cmdliner"
   "astring"
   "fmt"
   "logs" {>= "0.5.0"}

--- a/protocol-9p.opam
+++ b/protocol-9p.opam
@@ -24,7 +24,6 @@ depends: [
   "lwt" {>= "3.0.0"}
   "cmdliner"
   "astring"
-  "named-pipe" {>= "0.4.0"}
   "fmt"
   "logs" {>= "0.5.0"}
   "win-error"

--- a/unix/client9p_unix.ml
+++ b/unix/client9p_unix.ml
@@ -107,10 +107,6 @@ module Make(Log: S.LOG) = struct
         end
       | "unix", _ ->
         open_unix address
-      | _, address when Astring.String.is_prefix ~affix:"\\\\" address ->
-        Named_pipe_lwt.Client.openpipe address
-        >>= fun pipe ->
-        Lwt.return (Ok (Named_pipe_lwt.Client.to_fd pipe))
       | _ ->
         Lwt.return (Error.error_msg "Unknown protocol %s" proto)
     ) >>*= fun s ->

--- a/unix/jbuild
+++ b/unix/jbuild
@@ -3,6 +3,6 @@
 (library
  ((name        protocol_9p_unix)
   (public_name protocol-9p-unix)
-  (libraries   (result fmt lwt mirage-flow-lwt cstruct cstruct-lwt astring named-pipe.lwt
+  (libraries   (result fmt lwt mirage-flow-lwt cstruct cstruct-lwt astring
                 protocol-9p io-page.unix prometheus))
 ))


### PR DESCRIPTION
The `named-pipe` repo was deprecated and archived because its premise that a Windows named pipe could be treated like a Unix file descriptor was false. Named pipe users should use the `Uwt` library, construct a `FLOW` and instantiate the 9P client/server from that.

This PR also removes an unnecessary dependency on `cmdliner` from the core code and prepares to release 0.12.1.