### PR TITLE
remove old mirage-kv usage

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+## v2.0.0
+
+* Remove old `KV_RO` interface in the client as it has
+  been superseded by mirage-kv-2.0.  The new interface
+  will be re-added in a future release (@avsm)
+
 ## v1.0.1 (2019-02-07)
 
 * Use modern `io-page-unix` instead of `io-page.unix` (@avsm)

--- a/lib/dune
+++ b/lib/dune
@@ -2,6 +2,6 @@
  (name protocol_9p)
  (public_name protocol-9p)
  (libraries rresult cstruct sexplib lwt mirage-flow-lwt mirage-channel-lwt
-   mirage-kv-lwt astring fmt)
+   astring fmt)
  (preprocess
   (pps ppx_sexp_conv)))

--- a/lib/protocol_9p_client.mli
+++ b/lib/protocol_9p_client.mli
@@ -58,8 +58,6 @@ module type S = sig
     Protocol_9p_types.Stat.t Protocol_9p_error.t Lwt.t
   (** Return information about a named directory or named file. *)
 
-  module KV_RO : Mirage_kv_lwt.RO with type t = t
-
   module LowLevel : sig
     (** The functions in this module are mapped directly onto individual 9P
         RPCs. The client must carefully respect the rules on managing fids

--- a/protocol-9p.opam
+++ b/protocol-9p.opam
@@ -13,7 +13,6 @@ depends: [
   "sexplib" {> "113.00.00"}
   "rresult"
   "mirage-flow-lwt"
-  "mirage-kv-lwt"
   "mirage-channel-lwt"
   "lwt" {>= "3.0.0"}
   "astring"

--- a/unix/client9p_unix.ml
+++ b/unix/client9p_unix.ml
@@ -42,8 +42,6 @@ module Make(Log: S.LOG) = struct
     switch : Lwt_switch.t;
   }
 
-  type connection = t
-
   let pp_addr ppf = function
     | Lwt_unix.ADDR_UNIX path -> Fmt.pf ppf "unix:%s" path
     | Lwt_unix.ADDR_INET (host, port) ->
@@ -146,28 +144,6 @@ module Make(Log: S.LOG) = struct
   let readdir { client } = Client.readdir client
 
   let stat { client } = Client.stat client
-
-  module KV_RO = struct
-    open Client
-
-    type t = connection
-
-    type 'a io = 'a KV_RO.io
-
-    type error = KV_RO.error
-
-    let pp_error = KV_RO.pp_error
-
-    type page_aligned_buffer = KV_RO.page_aligned_buffer
-
-    let disconnect { client } = KV_RO.disconnect client
-
-    let read { client } = KV_RO.read client
-
-    let size { client } = KV_RO.size client
-
-    let mem { client } = KV_RO.mem client
-  end
 
   module LowLevel = struct
     open Client


### PR DESCRIPTION
This is holding back the mirage universe due to an upper bound on mirage-kv-lwt<2.  However, removing it does not seem to break any dependencies as datakit/vpnkit do not use KV_RO from 9p_client.

@djs55 do you know of any uses? Otherwise I'll just merge this and cut a quick release so docs.mirage.org can use the latest mirage libs.