### PR TITLE
opam: remove the 'build' directive on dune dependency

### DIFF
--- a/protocol-9p-tool.opam
+++ b/protocol-9p-tool.opam
@@ -7,7 +7,7 @@ doc: "https://mirage.github.io/ocaml-9p/"
 bug-reports: "https://github.com/mirage/ocaml-9p/issues"
 depends: [
   "ocaml" {>= "4.03.0"}
-  "dune" {build & >= "1.0"}
+  "dune" {>= "1.0"}
   "protocol-9p"
   "protocol-9p-unix"
   "base-bytes"

--- a/protocol-9p-unix.opam
+++ b/protocol-9p-unix.opam
@@ -7,7 +7,7 @@ doc: "https://mirage.github.io/ocaml-9p/"
 bug-reports: "https://github.com/mirage/ocaml-9p/issues"
 depends: [
   "ocaml" {>= "4.03.0"}
-  "dune" {build & >= "1.0"}
+  "dune" {>= "1.0"}
   "protocol-9p" {>="1.0.1"}
   "base-bytes"
   "cstruct" {>= "3.0.0"}

--- a/protocol-9p.opam
+++ b/protocol-9p.opam
@@ -7,7 +7,7 @@ doc: "https://mirage.github.io/ocaml-9p/"
 bug-reports: "https://github.com/mirage/ocaml-9p/issues"
 depends: [
   "ocaml" {>= "4.03.0"}
-  "dune" {build & >= "1.0"}
+  "dune" {>= "1.0"}
   "base-bytes"
   "cstruct" {>= "4.0.0"}
   "cstruct-sexp"


### PR DESCRIPTION
This directive results in failure when downgrading Dune versions, due to version-specific functionality in the Dune language. See https://github.com/ocaml/opam/issues/3850 for more details.