### PR TITLE
Use Cstruct.length (6.0.0+) and Fmt.str rather than Fmt.strf

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+## v2.0.2 (2021-01-16)
+
+* Update to Cstruct.length in cstruct.6.0.0 and use Fmt.str
+  rather than Fmt.strf (@djs55)
+
 ## v2.0.1 (2019-03-26)
 
 * Use cstruct-sexp introduced in cstruct.4.0.0 (@avsm)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,11 +2,13 @@ platform:
   - x86
 
 environment:
-  FORK_USER: ocaml
-  FORK_BRANCH: master
-  PINS: "protocol-9p:. protocol-9p-tool:. protocol-9p-unix:."
-  PACKAGE: protocol-9p-unix
-  CYG_ROOT: C:\cygwin64
+  global:
+    FORK_USER: ocaml
+    FORK_BRANCH: master
+    CYG_ROOT: C:\cygwin64
+    PINS: "protocol-9p:. protocol-9p-tool:. protocol-9p-unix:."
+    PACKAGE: protocol-9p-unix
+    OPAM_SWITCH: 4.08.0+mingw64c
 
 install:
   - ps: iex ((new-object net.webclient).DownloadString("https://raw.githubusercontent.com/$env:FORK_USER/ocaml-ci-scripts/$env:FORK_BRANCH/appveyor-install.ps1"))

--- a/lib/dune
+++ b/lib/dune
@@ -2,6 +2,6 @@
  (name protocol_9p)
  (public_name protocol-9p)
  (libraries rresult cstruct cstruct-sexp sexplib lwt mirage-flow mirage-channel
-   astring fmt)
+   astring fmt logs)
  (preprocess
   (pps ppx_sexp_conv)))

--- a/lib/protocol_9p_buffered9PReader.ml
+++ b/lib/protocol_9p_buffered9PReader.ml
@@ -39,7 +39,7 @@ module Make(Log: Protocol_9p_s.LOG)(FLOW: Mirage_flow.S) = struct
     C.read_exactly ~len c >>= function
     | Ok (`Data bufs) -> Lwt.return (Ok (Cstruct.concat bufs))
     | Ok `Eof -> Lwt.return (Error `Eof)
-    | Error e -> Lwt.return (Error (`Msg (Fmt.strf "%a" C.pp_error e)))
+    | Error e -> Lwt.return (Error (`Msg (Fmt.str "%a" C.pp_error e)))
 
   let read_must_have_lock t =
     let len_size = 4 in

--- a/lib/protocol_9p_client.ml
+++ b/lib/protocol_9p_client.ml
@@ -392,7 +392,7 @@ module Make(Log: Protocol_9p_s.LOG)(FLOW: Mirage_flow.S) = struct
         openfid t newfid Types.OpenMode.write_only
         >>*= fun _ ->
         let rec loop offset remaining =
-          let len = Cstruct.len remaining in
+          let len = Cstruct.length remaining in
           if len = 0
           then Lwt.return (Ok ())
           else begin
@@ -416,7 +416,7 @@ module Make(Log: Protocol_9p_s.LOG)(FLOW: Mirage_flow.S) = struct
           let to_request = min remaining t.maximum_payload in
           read t newfid offset to_request
           >>*= fun { Response.Read.data } ->
-          let n = Cstruct.len data in
+          let n = Cstruct.length data in
           if n = 0
           then Lwt.return (Ok (List.rev acc))
           else
@@ -495,15 +495,15 @@ module Make(Log: Protocol_9p_s.LOG)(FLOW: Mirage_flow.S) = struct
         let rec loop acc offset =
           read t newfid offset t.maximum_payload
           >>*= fun { Response.Read.data } ->
-          if Cstruct.len data = 0
+          if Cstruct.length data = 0
           then Lwt.return (Ok acc)
           else
             (* Data should be an integral number of marshalled Stat.ts *)
             let module StatArray = Types.Arr(Types.Stat) in
             (Lwt.return (StatArray.read data))
             >>*= fun (stats, rest) ->
-            assert (Cstruct.len rest = 0);
-            loop (acc @ stats) Int64.(add offset (of_int (Cstruct.len data))) in
+            assert (Cstruct.length rest = 0);
+            loop (acc @ stats) Int64.(add offset (of_int (Cstruct.length data))) in
         loop [] 0L
     )
 

--- a/lib/protocol_9p_error.ml
+++ b/lib/protocol_9p_error.ml
@@ -23,7 +23,7 @@ type 'a t = ('a, error) result
 
 let return x = Ok x
 
-let error_msg fmt = Fmt.kstrf (fun s -> Error (`Msg s)) fmt
+let error_msg fmt = Fmt.kstr (fun s -> Error (`Msg s)) fmt
 
 let ( >>= ) m f = match m with
   | Error x -> Error x

--- a/lib/protocol_9p_request.ml
+++ b/lib/protocol_9p_request.ml
@@ -78,7 +78,7 @@ module Auth = struct
     >>= fun (aname, rest) ->
     let uname = Data.to_string uname in
     let aname = Data.to_string aname in
-    if Cstruct.len rest = 0
+    if Cstruct.length rest = 0
     then return ({ afid; uname; aname; n_uname = None }, rest)
     else
       Int32.read rest
@@ -143,7 +143,7 @@ module Attach = struct
     >>= fun (aname, rest) ->
     let uname = Data.to_string uname in
     let aname = Data.to_string aname in
-    if Cstruct.len rest = 0
+    if Cstruct.length rest = 0
     then return ({ fid; afid; uname; aname; n_uname = None }, rest)
     else
       Int32.read rest
@@ -259,7 +259,7 @@ module Create = struct
     OpenMode.read rest
     >>= fun (mode, rest) ->
     let name = Data.to_string name in
-    if Cstruct.len rest = 0
+    if Cstruct.length rest = 0
     then return ({ fid; name; perm; mode; extension = None}, rest)
     else
       Data.read rest
@@ -306,14 +306,14 @@ module Write = struct
 
   let sizeof_header = 4 + 8 + 4
 
-  let sizeof t = (Fid.sizeof t.fid) + 8 + 4 + (Cstruct.len t.data)
+  let sizeof t = (Fid.sizeof t.fid) + 8 + 4 + (Cstruct.length t.data)
 
   let write t rest =
     Fid.write t.fid rest
     >>= fun rest ->
     Int64.write t.offset rest
     >>= fun rest ->
-    let len = Cstruct.len t.data in
+    let len = Cstruct.length t.data in
     Int32.write (Int32.of_int len) rest
     >>= fun rest ->
     big_enough_for "Write.data" rest len
@@ -501,7 +501,7 @@ let pp ppf = function
   | { tag; payload = Write { Write.fid; offset; data } } ->
     let tag = Types.Tag.to_int tag in
     let fid = Types.Fid.to_int32 fid in
-    let len = Cstruct.len data in
+    let len = Cstruct.length data in
     Format.fprintf ppf "tag %d Write(fid: %ld, offset: %Ld, len(data): %d)"
       tag fid offset len
   | t -> Sexplib.Sexp.pp_hum ppf (sexp_of_t t)

--- a/lib/protocol_9p_response.ml
+++ b/lib/protocol_9p_response.ml
@@ -58,7 +58,7 @@ module Err = struct
     Data.read buf
     >>= fun (ename, rest) ->
     let ename = Data.to_string ename in
-    if Cstruct.len rest = 0
+    if Cstruct.length rest = 0
     then return ({ ename; errno = None }, rest)
     else
       Int32.read rest
@@ -183,10 +183,10 @@ module Read = struct
 
   let sizeof_header = 4
 
-  let sizeof t = sizeof_header + (Cstruct.len t.data)
+  let sizeof t = sizeof_header + (Cstruct.length t.data)
 
   let write t rest =
-    let len = Cstruct.len t.data in
+    let len = Cstruct.length t.data in
     Int32.write (Int32.of_int len) rest
     >>= fun rest ->
     big_enough_for "Read.data" rest len
@@ -368,7 +368,7 @@ let read rest =
 let pp ppf = function
   | { tag; payload = Read { Read.data } } ->
     let tag = Types.Tag.to_int tag in
-    let len = Cstruct.len data in
+    let len = Cstruct.length data in
     Format.fprintf ppf "tag %d Read(len(data): %d)" tag len
   | t -> Sexplib.Sexp.pp_hum ppf (sexp_of_t t)
 

--- a/lib_test/lofs_test.ml
+++ b/lib_test/lofs_test.ml
@@ -245,7 +245,7 @@ let check_directory_boundary_read () =
         | Error (`Msg err) ->
           Alcotest.fail ("client1: read: " ^ err)
         | Ok { Response.Read.data } ->
-          let n = Cstruct.len data in
+          let n = Cstruct.length data in
           if n = 0
           then Lwt.return (Ok ())
           else Alcotest.fail ("client1: read non-zero: " ^ (string_of_int n))

--- a/lib_test/tests.ml
+++ b/lib_test/tests.ml
@@ -157,7 +157,7 @@ let test_requests = List.map (fun r ->
   ) requests
 
 let test_responses = List.map (fun r ->
-    Fmt.strf "print then parser random response", `Quick, print_parse_response r
+    Fmt.str "print then parser random response", `Quick, print_parse_response r
   ) responses
 
 let tests = [

--- a/lib_test/tests.ml
+++ b/lib_test/tests.ml
@@ -25,7 +25,7 @@ let () =
 
 let example_data =
   let data = Cstruct.create 1 in
-  for i = 0 to Cstruct.len data - 1 do
+  for i = 0 to Cstruct.length data - 1 do
     Cstruct.set_char data i '\000'
   done;
   data
@@ -129,10 +129,10 @@ let print_parse_request r () =
     Request.write r buf
     >>= fun remaining ->
     Cstruct.hexdump buf;
-    Alcotest.(check int) "write request" 0 (Cstruct.len remaining);
+    Alcotest.(check int) "write request" 0 (Cstruct.length remaining);
     Request.read (Cstruct.shift buf len_size)
     >>= fun (r', remaining) ->
-    Alcotest.(check int) "read request" 0 (Cstruct.len remaining);
+    Alcotest.(check int) "read request" 0 (Cstruct.length remaining);
     Alcotest.(check request) "request" r r';
     return ()
   )
@@ -144,10 +144,10 @@ let print_parse_response r () =
     let buf = Cstruct.create needed in
     Response.write r buf
     >>= fun remaining ->
-    Alcotest.(check int) "write response" 0 (Cstruct.len remaining);
+    Alcotest.(check int) "write response" 0 (Cstruct.length remaining);
     Response.read (Cstruct.shift buf len_size)
     >>= fun (r', remaining) ->
-    Alcotest.(check int) "read respsonse" 0 (Cstruct.len remaining);
+    Alcotest.(check int) "read respsonse" 0 (Cstruct.length remaining);
     Alcotest.(check response) "response" r r';
     return ()
   )

--- a/protocol-9p-tool.opam
+++ b/protocol-9p-tool.opam
@@ -14,12 +14,12 @@ depends: [
   "rresult"
   "logs" {>= "0.5.0"}
   "fmt"
-  "lambda-term" {>= "2.0.0"}
+  "lambda-term" {< "2.0"}
   "win-error"
   "cmdliner"
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
 ]
 dev-repo: "git+https://github.com/mirage/ocaml-9p.git"

--- a/protocol-9p-tool.opam
+++ b/protocol-9p-tool.opam
@@ -14,7 +14,7 @@ depends: [
   "rresult"
   "logs" {>= "0.5.0"}
   "fmt"
-  "lambda-term" {< "2.0"}
+  "lambda-term"
   "win-error"
   "cmdliner"
 ]

--- a/protocol-9p-unix.opam
+++ b/protocol-9p-unix.opam
@@ -10,13 +10,13 @@ depends: [
   "dune" {>= "1.0"}
   "protocol-9p" {>="1.0.1"}
   "base-bytes"
-  "cstruct" {>= "3.0.0"}
-  "cstruct-lwt" {>= "3.0.0"}
-  "sexplib" {> "113.00.00"}
+  "cstruct" {>= "3.0.0" & < "6.0.0"}
+  "cstruct-lwt" {>= "3.0.0" & < "6.0.0"}
+  "sexplib" {> "113.00.00" & < "v0.15"}
   "prometheus"
   "rresult"
-  "mirage-flow" {>= "2.0.0"}
-  "mirage-channel" {>= "4.0.0"}
+  "mirage-flow-lwt"
+  "mirage-channel-lwt"
   "lwt" {>= "3.0.0"}
   "base-unix"
   "astring"
@@ -24,11 +24,11 @@ depends: [
   "logs" {>= "0.5.0"}
   "win-error"
   "io-page-unix" {>= "2.0.0"}
-  "ppx_sexp_conv"
+  "ppx_sexp_conv" {< "v0.15"}
   "alcotest" {with-test & >= "0.4.0"}
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]

--- a/protocol-9p-unix.opam
+++ b/protocol-9p-unix.opam
@@ -15,8 +15,8 @@ depends: [
   "sexplib" {> "113.00.00" & < "v0.15"}
   "prometheus"
   "rresult"
-  "mirage-flow-lwt"
-  "mirage-channel-lwt"
+  "mirage-flow" {>= "3.0.0"}
+  "mirage-channel" {>= "4.0.0"}
   "lwt" {>= "3.0.0"}
   "base-unix"
   "astring"

--- a/protocol-9p-unix.opam
+++ b/protocol-9p-unix.opam
@@ -10,8 +10,8 @@ depends: [
   "dune" {>= "1.0"}
   "protocol-9p" {>="1.0.1"}
   "base-bytes"
-  "cstruct" {>= "3.0.0" & < "6.0.0"}
-  "cstruct-lwt" {>= "3.0.0" & < "6.0.0"}
+  "cstruct" {>= "6.0.0"}
+  "cstruct-lwt" {>= "6.0.0"}
   "sexplib" {> "113.00.00" & < "v0.15"}
   "prometheus"
   "rresult"

--- a/protocol-9p-unix.opam
+++ b/protocol-9p-unix.opam
@@ -16,12 +16,12 @@ depends: [
   "prometheus"
   "rresult"
   "mirage-flow" {>= "3.0.0"}
-  "mirage-channel" {>= "4.0.0"}
+  "mirage-channel" {with-test & >= "4.0.0"}
   "lwt" {>= "3.0.0"}
   "base-unix"
   "astring"
   "fmt"
-  "logs" {>= "0.5.0"}
+  "logs" {with-test & >= "0.5.0"}
   "win-error"
   "io-page-unix" {>= "2.0.0"}
   "ppx_sexp_conv" {< "v0.15"}

--- a/protocol-9p.opam
+++ b/protocol-9p.opam
@@ -13,8 +13,8 @@ depends: [
   "cstruct-sexp"
   "sexplib" {> "113.00.00" & < "v0.15"}
   "rresult"
-  "mirage-flow-lwt"
-  "mirage-channel-lwt"
+  "mirage-flow" {>= "3.0.0"}
+  "mirage-channel" {>= "4.0.0"}
   "lwt" {>= "3.0.0"}
   "astring"
   "fmt"

--- a/protocol-9p.opam
+++ b/protocol-9p.opam
@@ -9,22 +9,22 @@ depends: [
   "ocaml" {>= "4.03.0"}
   "dune" {>= "1.0"}
   "base-bytes"
-  "cstruct" {>= "4.0.0"}
+  "cstruct" {>= "4.0.0" & < "6.0.0"}
   "cstruct-sexp"
-  "sexplib" {> "113.00.00"}
+  "sexplib" {> "113.00.00" & < "v0.15"}
   "rresult"
-  "mirage-flow" {>= "2.0.0"}
-  "mirage-channel" {>= "4.0.0"}
+  "mirage-flow-lwt"
+  "mirage-channel-lwt"
   "lwt" {>= "3.0.0"}
   "astring"
   "fmt"
   "logs" {>= "0.5.0"}
   "win-error"
-  "ppx_sexp_conv" {>="v0.9.0"}
+  "ppx_sexp_conv" {>= "v0.9.0" & < "v0.15"}
   "alcotest" {with-test & >= "0.4.0"}
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
 ]
 dev-repo: "git+https://github.com/mirage/ocaml-9p.git"

--- a/protocol-9p.opam
+++ b/protocol-9p.opam
@@ -9,7 +9,7 @@ depends: [
   "ocaml" {>= "4.03.0"}
   "dune" {>= "1.0"}
   "base-bytes"
-  "cstruct" {>= "4.0.0" & < "6.0.0"}
+  "cstruct" {>= "6.0.0"}
   "cstruct-sexp"
   "sexplib" {> "113.00.00" & < "v0.15"}
   "rresult"

--- a/src/main.ml
+++ b/src/main.ml
@@ -85,7 +85,7 @@ let read debug address path username =
         let rec loop offset =
           Client.read t path offset two_mib
           >>*= fun data ->
-          let len = List.fold_left (+) 0 (List.map (fun x -> Cstruct.len x) data) in
+          let len = List.fold_left (+) 0 (List.map (fun x -> Cstruct.length x) data) in
           if len = 0
           then return (Ok ())
           else begin
@@ -266,7 +266,7 @@ let shell debug address username =
                 print_endline m;
                 return ()
               | Ok bufs ->
-                let len = List.fold_left (+) 0 (List.map Cstruct.len bufs) in
+                let len = List.fold_left (+) 0 (List.map Cstruct.length bufs) in
                 List.iter (fun x -> output_string stdout (Cstruct.to_string x)) bufs;
                 flush stdout;
                 if Int32.of_int len < requested
@@ -278,7 +278,7 @@ let shell debug address username =
           | "write" :: file :: rest ->
             let data = String.concat ~sep:" " rest in
             let buf = Cstruct.create (String.length data) in
-            Cstruct.blit_from_string data 0 buf 0 (Cstruct.len buf);
+            Cstruct.blit_from_string data 0 buf 0 (Cstruct.length buf);
             begin
               Client.write t (!cwd @ [ file ]) 0L buf
               >>= function

--- a/unix/flow_lwt_unix.ml
+++ b/unix/flow_lwt_unix.ml
@@ -55,7 +55,7 @@ let safe op f r =
 let read flow =
   if flow.closed then Lwt.return (Ok `Eof)
   else begin
-    if Cstruct.len flow.read_buffer = 0
+    if Cstruct.length flow.read_buffer = 0
     then flow.read_buffer <- Cstruct.create flow.read_buffer_size;
     safe Lwt_cstruct.read flow.fd flow.read_buffer >|= function
     | 0 -> Ok `Eof

--- a/unix/lofs9p.ml
+++ b/unix/lofs9p.ml
@@ -217,7 +217,7 @@ let make root = { root }
               let n = Types.Stat.sizeof stat in
               if off < offset
               then write Int64.(add off (of_int n)) rest xs
-              else if Cstruct.len rest < n then Lwt.return (Ok off)
+              else if Cstruct.length rest < n then Lwt.return (Ok off)
               else
                 Lwt.return (Types.Stat.write stat rest)
                 >>*= fun rest ->
@@ -430,7 +430,7 @@ let make root = { root }
           (fun () ->
             Lwt_unix.LargeFile.lseek fd offset Lwt_unix.SEEK_SET
             >>= fun _cursor ->
-            let len = Cstruct.len data in
+            let len = Cstruct.length data in
             Lwt_unix.write fd (Bytes.of_string (Cstruct.to_string data)) 0 len
           )
         >>= fun written ->


### PR DESCRIPTION
Also
- sync the opam files from opam-repository.
- update lower-bounds on mirage-flow, mirage-channel (was mirage-flow-lwt, mirage-channel-lwt)
- add missing dependency on `logs` in `lib/dune`
- update appveyor to 4.08 