### PR TITLE
Cmdliner 1.1.0 and updates for Mirage

### DIFF
--- a/protocol-9p-tool.opam
+++ b/protocol-9p-tool.opam
@@ -16,7 +16,7 @@ depends: [
   "fmt"
   "lambda-term"
   "win-error"
-  "cmdliner"
+  "cmdliner" { >= "1.1.0" }
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/protocol-9p.opam
+++ b/protocol-9p.opam
@@ -11,7 +11,7 @@ depends: [
   "base-bytes"
   "cstruct" {>= "6.0.0"}
   "cstruct-sexp"
-  "sexplib" {> "113.00.00" & < "v0.15"}
+  "sexplib" {> "113.00.00"}
   "rresult"
   "mirage-flow" {>= "3.0.0"}
   "mirage-channel" {>= "4.0.0"}
@@ -20,7 +20,7 @@ depends: [
   "fmt"
   "logs" {>= "0.5.0"}
   "win-error"
-  "ppx_sexp_conv" {>= "v0.9.0" & < "v0.15"}
+  "ppx_sexp_conv" {>= "v0.9.0"}
   "alcotest" {with-test & >= "0.4.0"}
 ]
 build: [

--- a/src/main.ml
+++ b/src/main.ml
@@ -396,8 +396,8 @@ let ls_cmd =
     `S "DESCRIPTION";
     `P "List the contents of a directory on the fileserver."
   ] @ help in
-  Term.(ret(pure ls $ debug $ address $ path $ username)),
-  Term.info "ls" ~doc ~man
+  Term.(ret(const ls $ debug $ address $ path $ username)),
+  Cmd.info "ls" ~doc ~man
 
 let read_cmd =
   let doc = "Read a file" in
@@ -405,8 +405,8 @@ let read_cmd =
     `S "DESCRIPTION";
     `P "Write the contents of a file to stdout.";
   ] @ help in
-  Term.(ret(pure read $ debug $ address $ path $ username)),
-  Term.info "read" ~doc ~man
+  Term.(ret(const read $ debug $ address $ path $ username)),
+  Cmd.info "read" ~doc ~man
 
 let remove_cmd =
   let doc = "Remove a file or directory" in
@@ -414,8 +414,8 @@ let remove_cmd =
     `S "DESCRIPTION";
     `P "Remove a file or directory.";
   ] @ help in
-  Term.(ret(pure remove $ debug $ address $ path $ username)),
-  Term.info "remove" ~doc ~man
+  Term.(ret(const remove $ debug $ address $ path $ username)),
+  Cmd.info "remove" ~doc ~man
 
 let serve_cmd =
   let doc = "Serve a directory over 9P" in
@@ -423,8 +423,8 @@ let serve_cmd =
     `S "DESCRIPTION";
     `P "Listen for 9P connections and serve the named filesystem.";
   ] @ help in
-  Term.(ret(pure serve $ debug $ address $ path)),
-  Term.info "serve" ~doc ~man
+  Term.(ret(const serve $ debug $ address $ path)),
+  Cmd.info "serve" ~doc ~man
 
 let shell_cmd =
   let doc = "Run an interactive 9P session" in
@@ -432,20 +432,18 @@ let shell_cmd =
     `S "DESCRIPTION";
     `P "Connect to a 9P server and present a shell-like interface."
   ] @ help in
-  Term.(ret(pure shell $ debug $ address $ username)),
-  Term.info "shell" ~doc ~man
+  Term.(ret(const shell $ debug $ address $ username)),
+  Cmd.info "shell" ~doc ~man
 
-let default_cmd =
+let default_cmd, default_info =
   let doc = "interact with a remote machine over 9P" in
   let man = help in
-  Term.(ret (pure (`Help (`Pager, None)))),
-  Term.info (Sys.argv.(0)) ~version ~doc ~man
+  Term.(ret (const (`Help (`Pager, None)))),
+  Cmd.info (Sys.argv.(0)) ~version ~doc ~man
 
-let all_cmds = [
+let all_cmds = Cmd.group default_info @@ List.map (fun (t, i) -> Cmd.v i t) [
   ls_cmd; read_cmd; remove_cmd; serve_cmd; shell_cmd;
 ]
 
-let _ =
-  match Term.eval_choice default_cmd all_cmds with
-  | `Error _ -> exit 1
-  | _ -> exit 0
+let () = 
+  exit (Cmd.eval all_cmds)

--- a/unix/flow_lwt_unix.ml
+++ b/unix/flow_lwt_unix.ml
@@ -91,3 +91,12 @@ let writev flow bufs =
         loop xs
   in
   protect (fun () -> loop bufs)
+
+let shutdown flow cmd =
+  let cmd' = match cmd with
+    | `write -> Lwt_unix.SHUTDOWN_SEND
+    | `read -> SHUTDOWN_RECEIVE
+    | `read_write -> SHUTDOWN_ALL
+  in
+  Lwt_unix.shutdown flow.fd cmd';
+  Lwt.return_unit


### PR DESCRIPTION
A few updates to help brind ocaml-9p back up to speed with the rest of the ecosystem:

 - Cmdliner 1.1.0: most packages I think have made this switch
 - Removed the ppx_sexp_conv upper bounds, I actually don't think these were necessary
 - Compatible with `mirage-flow.5.0.0`

We'll see what CI makes of it.